### PR TITLE
Adding CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+*	@ricardozanini @krisv
+
+*.adoc 	@hmanwani-rh
+*.yml	@akumar074 @amadhusu
+*.json	@akumar074 @amadhusu


### PR DESCRIPTION
Adding [CODEOWNERS](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) file to enforce reviewers.