### PR TITLE
KOGITO-7232: Push GH action on main to deploy on GH pages

### DIFF
--- a/.github/workflows/npm-publish-pages.yml
+++ b/.github/workflows/npm-publish-pages.yml
@@ -4,26 +4,34 @@
 name: Node.js Publish webpage
 
 on:
-  release:
-    types: [created]
+  push:
+    branches: [ "main" ]
   workflow_dispatch:
+
+permissions:
+  contents: write
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16
-      - run: npm ci
-      - run: npm run install-build
-      - name: Deploy with gh-pages
-        shell: bash
-        working-directory: ./build/site
-        run: |
-          git remote set-url origin https://git:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
-          npx gh-pages -d ./ -u "github-actions-bot <support+actions@github.com>" b gh-pages
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"  
 
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [16.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    - run: npm ci
+    - run: npm run install-build
+    - name: Publish to GitHub Pages
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: build/site

--- a/.github/workflows/npm-publish-pages.yml
+++ b/.github/workflows/npm-publish-pages.yml
@@ -1,0 +1,28 @@
+# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
+
+name: Node.js Publish webpage
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - run: npm ci
+      - run: npm run install-build
+      - name: Deploy with gh-pages
+        shell: bash
+        working-directory: ./build/site
+        run: |
+          git remote set-url origin https://git:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+          npx gh-pages -d ./ -u "github-actions-bot <support+actions@github.com>" b gh-pages
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"  
+

--- a/.github/workflows/npm-publish-pages.yml
+++ b/.github/workflows/npm-publish-pages.yml
@@ -5,7 +5,8 @@ name: Node.js Publish webpage
 
 on:
   push:
-    branches: [ "main" ]
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/npm-publish-pages.yml
+++ b/.github/workflows/npm-publish-pages.yml
@@ -6,6 +6,7 @@ name: Node.js Publish webpage
 on:
   release:
     types: [created]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/README.adoc
+++ b/README.adoc
@@ -12,9 +12,13 @@ This folder contains `package.json` files that you can use to install dependenci
 
 == Building the website locally
 
-This folder contains an antora playbook, `antora-playbook-author.yml` to generate the documentation. To run and generate the documentation locally under the `build` folder use:
+This folder contains an antora playbook, `antora-playbook-author.yml` to generate the documentation under the `build` folder. 
 
-`npx antora antora-playbook-author.yml`
+To install and build the Antora site locally use:
+`npm run local-install-build`
+
+To build Antora site when you have already installed `npm` dependencies, use:
+`npm run local-build`
 
 == How it works
 


### PR DESCRIPTION
This Github action is run on every pull request merged into the main branch. This action will upload the build artifacts to gh-pages branch. Github pages will render this content.