### PR TITLE
KOGITO-7232: Push kogito-docs build to GH Pages

### DIFF
--- a/.github/workflows/npm-publish-pages.yml
+++ b/.github/workflows/npm-publish-pages.yml
@@ -28,7 +28,7 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
-        cache: 'npm'
+#        cache: 'npm'
     - run: npm ci
     - run: npm run install-build
     - name: Publish to GitHub Pages


### PR DESCRIPTION
 - Disabled npm cache due to GH action bug 
 https://github.com/bahmutov/npm-install/issues/80