### PR TITLE
KOGITO-6458: Update the guide to describe new feature of default security definition

### DIFF
--- a/serverlessworkflow/modules/ROOT/pages/security/authention-support-for-openapi-services.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/security/authention-support-for-openapi-services.adoc
@@ -47,7 +47,7 @@ The following shows the example of security scheme definitions:
     }
 ----
 
-If the OpenAPI specification file has `securitySchemes` definitions, but no link:https://spec.openapis.org/oas/v3.1.0#security-requirement-object[Security Requirement Object] definitions, the generator can be configured to create these by default. In this case, for all operations without a security requirement the default one will be created. Note that the property value needs to match the name of a security scheme object definition, eg. `http-basic-example` or `api-key-example` in the `securitySchemes` list above.
+If the OpenAPI specification file contains `securitySchemes` definitions, but not link:{open_api_spec_url}[Security Requirement Object] definitions, the generator can be configured to create the security requirement objects by default. In this case, for all operations without a security requirement, the default one is created. Note that the property value needs to match the name of a security scheme object definition, such as `http-basic-example` or `api-key-example` in the previous `securitySchemes` list.
 
 [cols="20%,40%,40%", options="header"]
 |===

--- a/serverlessworkflow/modules/ROOT/pages/security/authention-support-for-openapi-services.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/security/authention-support-for-openapi-services.adoc
@@ -47,6 +47,18 @@ The following shows the example of security scheme definitions:
     }
 ----
 
+If the OpenAPI specification file has `securitySchemes` definitions, but no link:https://spec.openapis.org/oas/v3.1.0#security-requirement-object[Security Requirement Object] definitions, the generator can be configured to create these by default. In this case, for all operations without a security requirement the default one will be created. Note that the property value needs to match the name of a security scheme object definition, eg. `http-basic-example` or `api-key-example` in the `securitySchemes` list above.
+
+[cols="20%,40%,40%", options="header"]
+|===
+|Description |Property Key |Example
+
+|Create security for the referenced security scheme
+|`quarkus.openapi-generator.codegen.default.security.scheme`
+|`quarkus.openapi-generator.codegen.default.security.scheme=http-basic-example`
+
+|===
+
 To configure the credentials that are used to access the secured OpenAPI service operations and related parameters, you must use the application properties that are related to the security schemes.
 
 To compose the configuration keys, use the following format:
@@ -54,7 +66,7 @@ To compose the configuration keys, use the following format:
 .Format for configuration keys
 [source, properties]
 ----
-quarkus.openapi-generator.[filename].[security_scheme_name].auth.[auth_property_name]
+quarkus.openapi-generator.[filename].auth.[security_scheme_name].[auth_property_name]
 ----
 
 The previous format includes the following parameters:


### PR DESCRIPTION
Add a new section in the guide to describe the feature provided by KOGITO-6458:
- new property "quarkus.openapi-generator.codegen.default.security.scheme"
- create security bindings if property value matches any of the defined securityScheme definitions

JIRA: https://issues.redhat.com/browse/KOGITO-6458
Related commit: https://github.com/quarkiverse/quarkus-openapi-generator/commit/ccacff5e212aa6c615a44dfec69958ca5e248478
