### PR TITLE
KOGITO-7313 Added "Mocking OpenAPI services with WireMock" guide

### DIFF
--- a/serverlessworkflow/modules/ROOT/nav.adoc
+++ b/serverlessworkflow/modules/ROOT/nav.adoc
@@ -30,7 +30,7 @@
 //** xref:security/orchestrating-third-party-services-with-oauth2.adoc[Orchestrating third party services with OAuth2 authentication]
 * Testing and Troubleshooting
 //** xref:testing-and-troubleshooting/mocking-http-cloudevents-with-wiremock.adoc[Mocking HTTP CloudEvents sink with Wiremock]
-//** xref:testing-and-troubleshooting/mocking-opnapi-services-with-wiremock.adoc[Mocking OpenAPI Services with Wiremock]
+** xref:testing-and-troubleshooting/mocking-opnapi-services-with-wiremock.adoc[Mocking OpenAPI Services with Wiremock]
 ** xref:testing-and-troubleshooting/basic-integration-tests-with-restassured.adoc[Testing your Serverless Workflow application using REST Assured]
 //** xref:testing-and-troubleshooting/debugging-workflow-execution-runtime.adoc[Debugging the workflow execution in runtime]
 //** xref:testing-and-troubleshooting/integration-tests-with-postgresql.adoc[Integration Test with PostgreSQL]

--- a/serverlessworkflow/modules/ROOT/pages/testing-and-troubleshooting/mocking-opnapi-services-with-wiremock.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/testing-and-troubleshooting/mocking-opnapi-services-with-wiremock.adoc
@@ -1,1 +1,310 @@
-//= Mocking OpenAPI Services with Wiremock
+Mocking OpenAPI services with WireMock
+======================================
+// Metadata:
+:description: Mocking OpenAPI services with WireMock
+:keywords: kogito, workflow, quarkus, serverless, quarkus-cli, test, wiremock, openapi
+// links:
+:wiremock_url: https://wiremock.org/docs/
+:kogito_examples_url: https://github.com/kiegroup/kogito-examples.git
+:quarkus_test_resource_url: https://quarkus.io/guides/getting-started-testing#quarkus-test-resource
+// Referenced documentation pages.
+:getting-familiar-with-our-tooling: xref:getting-started/getting-familiar-with-our-tooling.adoc
+:create-your-first-workflow-service: xref:getting-started/create-your-first-workflow-service.adoc
+:orchestration-of-openapi-based-services: xref:service-orchestration/orchestration-of-openapi-based-services.adoc
+
+This document describes how to mock OpenAPI services using WireMock. The testing procedure in this document is based on the `serverless-workflow-examples/serverless-workflow-service-calls-quarkus` example application. You can access this example application in link:{kogito_examples_url}[Kogito Examples] GitHub repository.
+
+== Prerequisites
+
+The examples in this document assumes that you have the following prerequisites:
+
+* You have installed the Kogito tooling.
+
++
+--
+For more information about the tooling, see {getting-familiar-with-our-tooling}[Using Serverless Workflow tooling].
+--
+
+* You have created a Serverless Workflow project that orchestrates OpenAPI services.
+
++
+--
+For more information about creating a Serverless Workflow project, see {create-your-first-workflow-service}[Creating your first Serverless Workflow service].
+--
+
++
+--
+For more information about orchestrating OpenAPI services, see {orchestration-of-openapi-based-services}[Orchestrating the OpenAPI services].
+--
+
+== About WireMock
+
+WireMock is an open source API mocking for unit, integration and performance testing. You can use it to isolate your tests from 3rd party APIs and prototype APIs that still don't exist.
+
+For more information about WireMock, see the {wiremock_url}[WireMock documentation].
+
+== Adding a mocked OpenAPI service to your tests
+
+The following procedure describes how to add WireMock to your Serverless Workflow application:
+
+.Procedure
+
+. Add the WireMock dependency to your `pom.xml` file.
+
++
+--
+.WireMock dependency
+[source,xml]
+----
+<dependency>
+    <groupId>com.github.tomakehurst</groupId>
+    <artifactId>wiremock-jre8</artifactId>
+    <version>{wiremock.version}</version>
+    <scope>test</scope>
+</dependency>
+----
+
+[NOTE]
+====
+Replace `{wiremock.version}` with the version of WireMock you want to use.
+====
+--
+
+. Choose when you want to start your WireMock server. There are two options:
+
+* Start WireMock server as a `QuarkusTestResource`. This means that your WireMock server will be started once before all your tests and stopped after all your tests. This is the option that fits most cases.
+* Start a WireMock server independently for each test. This is useful if you need different behavior for each test.
+
+. Define how the WireMock server should be started.
+
++
+--
+.Starting a WireMock server example
+[source,java]
+----
+WireMockConfiguration config = WireMockConfiguration.wireMockConfig().dynamicPort(); <1>
+WireMockServer wireMockServer = new WireMockServer(config); <2>
+wireMockServer.start(); <3>
+----
+<1> Creates the configuration for the WireMock server. It's a good practice to use a dynamic port when possible. This way, you prevent the tests from failing due to port conflicts. When using a dynamic port is not possible, you can use the `WireMockConfiguration#port(int)` method to use a fixed port number.
+<2> Creates the WireMock server instance.
+<3> Starts the WireMock server.
+--
+
+. Mock the endpoints.
+
++
+--
+.Mocking endpoints example
+[source,java]
+----
+ObjectMapper objectMapper = new ObjectMapper();
+JsonNode greecePayload = objectMapper.readTree(getClass().getResourceAsStream("/country_mock.json")); <1>
+
+wireMockServer.stubFor(WireMock.get(WireMock.urlEqualTo("/rest/v2/name/Greece")) <2>
+                               .willReturn(WireMock.aResponse() <3>
+                                                   .withStatus(200) <4>
+                                                   .withHeader("Content-Type", "application/json") <5>
+                                                   .withJsonBody(greecePayload))); <6>
+----
+<1> Creates the JSON payload that will be returned by the WireMock server. Alternatively, you can use the `ResponseDefinitionBuilder#withBody` method to define a `String` or a `byte[]` as the response body.
+<2> Defines a stub for the `/rest/v2/name/Greece` endpoint.
+<3> Defines the response for the stub.
+<4> Defines the response status.
+<5> Defines the response headers.
+<6> Defines the response body.
+--
+
+. Stop the WireMock server.
+
++
+--
+.Stopping a WireMock server example
+[source,java]
+----
+wireMockServer.stop();
+----
+--
+
+=== Starting a WireMock server as a `QuarkusTestResource`
+
+The following procedure describes how to start a WireMock server as a `QuarkusTestResource`.
+
+.Procedure
+
+. Create a class that implements the `QuarkusTestResource` interface.
+
++
+--
+.QuarkusTestResource implementation example
+[source,java]
+----
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+
+public class RestCountriesMockServer implements QuarkusTestResourceLifecycleManager {
+
+    private WireMockServer wireMockServer;
+
+    @Override
+    public Map<String, String> start() { <1>
+        configureWiremockServer();
+        return Map.of("quarkus.rest-client.restcountries_json.url", wireMockServer.baseUrl() + "/rest"); <2>
+    }
+
+    private void configureWiremockServer() {
+        wireMockServer = new WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort());
+        wireMockServer.start();
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode greecePayload;
+        try {
+            greecePayload = objectMapper.readTree(getClass().getResourceAsStream("/country_mock.json"));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        wireMockServer.stubFor(get(urlEqualTo("/rest/v2/name/Greece"))
+                                       .willReturn(aResponse()
+                                                           .withStatus(200)
+                                                           .withHeader("Content-Type", "application/json")
+                                                           .withJsonBody(greecePayload)));
+    }
+
+    @Override
+    public void stop() { <3>
+        if (wireMockServer != null) {
+            wireMockServer.stop();
+        }
+    }
+}
+----
+<1> Start the test resource. This method is called once before all tests.
+<2> Returns a map of environment variables that will be set in the test environment. In this case, it sets the `quarkus.rest-client.restcountries_json.url` environment variable to the base URL of the WireMock server.
+<3> Stop the test resource. This method is called once after all tests.
+--
+
+. Use the `QuarkusTestResource` implementation in your test class.
+
++
+--
+.Example of a test class using the `QuarkusTestResource` implementation
+[source,java]
+----
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@QuarkusTestResource(RestCountriesMockServer.class) <1>
+class CountryServiceWorkflowTest {
+
+    @Test
+    void testFeatureA() {
+        // ...
+    }
+
+    @Test
+    void testFeatureB() {
+        // ...
+    }
+}
+----
+<1> Uses the `RestCountriesMockServer` class as a test resource.
+--
+
++
+--
+For more information about `QuarkusTestResource`, see {quarkus_test_resource_url}[Starting services before the Quarkus application starts].
+--
+
+=== Starting a WireMock server to be used in a specific test
+
+The following procedure describes how to start a WireMock server to be used in a specific test.
+
+.Procedure
+
+. Wrap the test logic between starting and stopping the WireMock server.
+
++
+--
+.Example of a test using a specific WireMock server instance
+[source,java]
+----
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+
+@QuarkusTest
+class CountryServiceWorkflowTest {
+
+    @Test
+    void testFeatureA() throws IOException {
+        WireMockServer wireMockServer = startWiremockServerForFeatureA();
+        try {
+            // test logic
+        } finally {
+            wireMockServer.stop();
+        }
+    }
+
+    @Test
+    void testFeatureB() {
+        WireMockServer wireMockServer = startWiremockServerForFeatureB();
+        try {
+            // test logic
+        } finally {
+            wireMockServer.stop();
+        }
+    }
+
+    private static WireMockServer startWiremockServerForFeatureA() throws IOException {
+        WireMockServer wireMockServer = new WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort());
+        wireMockServer.start();
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode greecePayload = objectMapper.readTree(CountryServiceWorkflowTest.class.getResourceAsStream("/country_mock_feature_a.json"));
+        wireMockServer.stubFor(get(urlEqualTo("/rest/v2/name/Greece"))
+                                       .willReturn(aResponse()
+                                                           .withStatus(200)
+                                                           .withHeader("Content-Type", "application/json")
+                                                           .withJsonBody(greecePayload)));
+
+        return wireMockServer;
+    }
+
+    private static WireMockServer startWiremockServerForFeatureB() {
+        WireMockServer wireMockServer = new WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort());
+        wireMockServer.start();
+
+        wireMockServer.stubFor(get(urlEqualTo("/rest/v2/name/Greece"))
+                                       .willReturn(aResponse().withStatus(404)));
+
+        return wireMockServer;
+    }
+}
+----
+--
+
+== Testing your Serverless Workflow application
+
+To test your Serverless Workflow application, you can follow the instructions in the xref:testing-and-troubleshooting/basic-integration-tests-with-restassured.adoc[Basic Integration Test with RestAssured] guide.

--- a/serverlessworkflow/modules/ROOT/pages/testing-and-troubleshooting/mocking-opnapi-services-with-wiremock.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/testing-and-troubleshooting/mocking-opnapi-services-with-wiremock.adoc
@@ -23,7 +23,7 @@ The examples in this document assumes that you have the following prerequisites:
 
 == About WireMock
 
-WireMock is an open source API mocking for unit, integration and performance testing. You can use it to isolate your tests from 3rd party APIs and prototype APIs that still don't exist.
+WireMock is an open source Mocking API for unit, integration and performance tests. You can use it to isolate your tests from 3rd party APIs and prototype APIs that still don't exist.
 
 For more information about WireMock, see the {wiremock_url}[WireMock documentation].
 

--- a/serverlessworkflow/modules/ROOT/pages/testing-and-troubleshooting/mocking-opnapi-services-with-wiremock.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/testing-and-troubleshooting/mocking-opnapi-services-with-wiremock.adoc
@@ -172,7 +172,7 @@ public class RestCountriesMockServer implements QuarkusTestResourceLifecycleMana
 }
 ----
 <1> Start the test resource. This method is called once before all tests.
-<2> Returns a map of environment variables that will be set in the test environment. In this case, it sets the `quarkus.rest-client.restcountries_json.url` environment variable to the base URL of the WireMock server.
+<2> Returns a map of application properties that will be set in the test environment. In this case, it sets the `quarkus.rest-client.restcountries_json.url` property to the base URL of the WireMock server.
 <3> Stop the test resource. This method is called once after all tests.
 --
 

--- a/serverlessworkflow/modules/ROOT/pages/testing-and-troubleshooting/mocking-opnapi-services-with-wiremock.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/testing-and-troubleshooting/mocking-opnapi-services-with-wiremock.adoc
@@ -5,7 +5,6 @@ Mocking OpenAPI services with WireMock
 :keywords: kogito, workflow, quarkus, serverless, quarkus-cli, test, wiremock, openapi
 // links:
 :wiremock_url: https://wiremock.org/docs/
-:kogito_examples_url: https://github.com/kiegroup/kogito-examples.git
 :quarkus_test_resource_url: https://quarkus.io/guides/getting-started-testing#quarkus-test-resource
 // Referenced documentation pages.
 :getting-familiar-with-our-tooling: xref:getting-started/getting-familiar-with-our-tooling.adoc

--- a/serverlessworkflow/modules/ROOT/pages/testing-and-troubleshooting/mocking-opnapi-services-with-wiremock.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/testing-and-troubleshooting/mocking-opnapi-services-with-wiremock.adoc
@@ -11,7 +11,7 @@ Mocking OpenAPI services with WireMock
 :create-your-first-workflow-service: xref:getting-started/create-your-first-workflow-service.adoc
 :orchestration-of-openapi-based-services: xref:service-orchestration/orchestration-of-openapi-based-services.adoc
 
-This document describes how to mock OpenAPI services using WireMock. The testing procedure in this document is based on the `serverless-workflow-examples/serverless-workflow-service-calls-quarkus` example application. You can access this example application in link:{kogito_examples_url}[Kogito Examples] GitHub repository.
+This document describes how to mock OpenAPI services using WireMock. The testing procedure in this document is based on the `serverless-workflow-examples/serverless-workflow-service-calls-quarkus` example application. You can access this example application in the link:{kogito_sw_examples_url}/serverless-workflow-service-calls-quarkus[GitHub repository].
 
 == Prerequisites
 

--- a/serverlessworkflow/modules/ROOT/pages/testing-and-troubleshooting/mocking-opnapi-services-with-wiremock.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/testing-and-troubleshooting/mocking-opnapi-services-with-wiremock.adoc
@@ -290,3 +290,5 @@ class CountryServiceWorkflowTest {
 == Testing your Serverless Workflow application
 
 To test your Serverless Workflow application, you can follow the instructions in the xref:testing-and-troubleshooting/basic-integration-tests-with-restassured.adoc[Basic Integration Test with RestAssured] guide.
+
+include::../../pages/_common-content/report-issue.adoc[]

--- a/serverlessworkflow/modules/ROOT/pages/testing-and-troubleshooting/mocking-opnapi-services-with-wiremock.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/testing-and-troubleshooting/mocking-opnapi-services-with-wiremock.adoc
@@ -19,17 +19,7 @@ The examples in this document assumes that you have the following prerequisites:
 
 * You have installed the {getting-familiar-with-our-tooling}[Kogito tooling].
 
-* You have created a Serverless Workflow project that orchestrates OpenAPI services.
-
-+
---
-For more information about creating a Serverless Workflow project, see {create-your-first-workflow-service}[Creating your first Serverless Workflow service].
---
-
-+
---
-For more information about orchestrating OpenAPI services, see {orchestration-of-openapi-based-services}[Orchestrating the OpenAPI services].
---
+* You have {create-your-first-workflow-service}[created a Serverless Workflow project] that {orchestration-of-openapi-based-services}[orchestrates OpenAPI services].
 
 == About WireMock
 

--- a/serverlessworkflow/modules/ROOT/pages/testing-and-troubleshooting/mocking-opnapi-services-with-wiremock.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/testing-and-troubleshooting/mocking-opnapi-services-with-wiremock.adoc
@@ -54,7 +54,7 @@ Replace `{wiremock.version}` with the version of WireMock you want to use.
 
 . Choose when you want to start your WireMock server. There are two options:
 
-* Start WireMock server as a `QuarkusTestResource`. This means that your WireMock server will be started once before all your tests and stopped after all your tests. This is the option that fits most cases.
+* Start WireMock server as a `QuarkusTestResource`. This means that your WireMock server will be started once before to run any test and will be stopped once the tests finishes. This is the option that fits most use cases.
 * Start a WireMock server independently for each test. This is useful if you need different behavior for each test.
 
 . Define how the WireMock server should be started.

--- a/serverlessworkflow/modules/ROOT/pages/testing-and-troubleshooting/mocking-opnapi-services-with-wiremock.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/testing-and-troubleshooting/mocking-opnapi-services-with-wiremock.adoc
@@ -17,12 +17,7 @@ This document describes how to mock OpenAPI services using WireMock. The testing
 
 The examples in this document assumes that you have the following prerequisites:
 
-* You have installed the Kogito tooling.
-
-+
---
-For more information about the tooling, see {getting-familiar-with-our-tooling}[Using Serverless Workflow tooling].
---
+* You have installed the {getting-familiar-with-our-tooling}[Kogito tooling].
 
 * You have created a Serverless Workflow project that orchestrates OpenAPI services.
 

--- a/serverlessworkflow/modules/ROOT/pages/testing-and-troubleshooting/mocking-opnapi-services-with-wiremock.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/testing-and-troubleshooting/mocking-opnapi-services-with-wiremock.adoc
@@ -23,9 +23,7 @@ The examples in this document assumes that you have the following prerequisites:
 
 == About WireMock
 
-WireMock is an open source Mocking API for unit, integration and performance tests. You can use it to isolate your tests from 3rd party APIs and prototype APIs that still don't exist.
-
-For more information about WireMock, see the {wiremock_url}[WireMock documentation].
+{wiremock_url}[WireMock] is an open source Mocking API for unit, integration and performance tests. You can use it to isolate your tests from 3rd party APIs and prototype APIs that still don't exist.
 
 == Adding a mocked OpenAPI service to your tests
 


### PR DESCRIPTION
<!-- Please don't forget your JIRA link -->
**JIRA:** https://issues.redhat.com/browse/KOGITO-7313

------------

- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [x] The nav.adoc file has a link to this guide in the proper category
