### PR TITLE
Fixed broken link

### DIFF
--- a/serverlessworkflow/modules/ROOT/pages/core/understanding-jq-expressions.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/core/understanding-jq-expressions.adoc
@@ -55,7 +55,7 @@ The Serverless Workflow Specification requires all the expressions to be embedde
 
 In the Serverless Workflow Specification, you can define link:{spec_doc_url}#workflow-functions[workflow functions], which can be invoked several times by the workflow states. Each workflow function call might contain different arguments, which are specified using the function arguments.
 
-For example, you can see the link:{kogito_sw_examples_url}/serverless-workflow-temperature-conversion/conversion-workflow/src/main/resources/fahrenheit-to-celsius.sw.json[temperature conversion] function definition in `serverless-workflow-temperature-conversion` example application. The temperature conversion function performs OpenAPI invocations to convert Fahrenheit to Celsius. For more information about OpenAPI, see xref:core/orchestration-of-openapi-based-services.adoc[Orchestrating the OpenAPI services].
+For example, you can see the link:{kogito_sw_examples_url}/serverless-workflow-temperature-conversion/conversion-workflow/src/main/resources/fahrenheit-to-celsius.sw.json[temperature conversion] function definition in `serverless-workflow-temperature-conversion` example application. The temperature conversion function performs OpenAPI invocations to convert Fahrenheit to Celsius. For more information about OpenAPI, see xref:service-orchestration/orchestration-of-openapi-based-services.adoc[Orchestrating the OpenAPI services].
 
 Following is the `subtraction` function in `serverless-workflow-temperature-conversion` example application:
 


### PR DESCRIPTION
This PR fixes a broken link in serverlessworkflow/modules/ROOT/pages/core/understanding-jq-expressions.adoc