### PR TITLE
Fixed broken link

### DIFF
--- a/serverlessworkflow/modules/ROOT/pages/core/understanding-jq-expressions.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/core/understanding-jq-expressions.adoc
@@ -176,6 +176,6 @@ In the previous example, the workflow model is changed by the `input` property o
 
 == Additional resources
 
-* xref:service-orchestration/orchestration-of-opnapi-based-services.adoc[Configuring OpenAPI services endpoints]
+* xref:service-orchestration/orchestration-of-openapi-based-services.adoc[Configuring OpenAPI services endpoints]
 
 include::../../pages/_common-content/report-issue.adoc[]


### PR DESCRIPTION
Fixed broken link in serverlessworkflow/modules/ROOT/pages/core/understanding-jq-expressions.adoc.