### PR TITLE
KOGITO-7693: Fixed table data overflow for large word

### DIFF
--- a/antora/supplemental-ui/css/custom.css
+++ b/antora/supplemental-ui/css/custom.css
@@ -2,3 +2,7 @@
     font-weight: bold;
     font-style: italic;
 }
+
+td {
+    word-break: break-all;
+}


### PR DESCRIPTION
**JIRA:** https://issues.redhat.com/browse/KOGITO-7693

**Description:**
When table data cell has long words, the table width increases to cover the longer word.

<!-- Link to related PRs: -->

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributions doc](https://github.com/kiegroup/kogito-docs/blob/main/CONTRIBUTING.md)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [x] The nav.adoc file has a link to this guide in the proper category
- [x] The index.adoc file has a card to this guide in the proper category, with a meaningful description
