### PR TITLE
Added 1.24.x and 1.25.x branches for generation

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -7,7 +7,10 @@ antora:
 content:
   sources:
     - url: git@github.com:kiegroup/kogito-docs.git
-      branches: [main]
+      branches: 
+        - main
+        - 1.24.x
+        - 1.25.x
       start_path: serverlessworkflow
 runtime:
   fetch: true

--- a/serverlessworkflow/modules/ROOT/pages/eventing/handling-events-on-workflows.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/eventing/handling-events-on-workflows.adoc
@@ -132,7 +132,7 @@ To start a new workflow instance, set the `start` property to the event state na
 
 An event state can also be used to pause an existing workflow instance. When the workflow execution reaches an event state, which is not starting, then the execution is paused until there is an event match for that workflow instance.
 
-Similar to the callback state in Serverless Workflow, the workflow instance to be resumed is identified by `kogitoprocrefid` CloudEvent attribute or calculated according to the xref:event-correlation-with-workflows.adoc[event correlation] functionality. While callback state is used for _fire&wait_ scenaiors, event state covers _wait&fire_ scenarios. For more information about callback state, see xref:eventing/working-with-callbacks.adoc[Callback state in Serverless Workflow].
+Similar to the callback state in Serverless Workflow, the workflow instance to be resumed is identified by `kogitoprocrefid` CloudEvent attribute or calculated according to the xref:eventing/event-correlation-with-workflows.adoc[event correlation] functionality. While callback state is used for _fire&wait_ scenaiors, event state covers _wait&fire_ scenarios. For more information about callback state, see xref:eventing/working-with-callbacks.adoc[Callback state in Serverless Workflow].
 
 == Additional resources
 


### PR DESCRIPTION
Depends on:
- 1.24.x => https://github.com/kiegroup/kogito-docs/pull/118
- 1.25.x => https://github.com/kiegroup/kogito-docs/pull/121

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributions doc](https://github.com/kiegroup/kogito-docs/blob/main/CONTRIBUTING.md)
- [ ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [ ] The nav.adoc file has a link to this guide in the proper category
- [ ] The index.adoc file has a card to this guide in the proper category, with a meaningful description
