### PR TITLE
KOGITO-7694 Fixed kn commands in create-your-first-workflow-service.adoc

### DIFF
--- a/serverlessworkflow/antora.yml
+++ b/serverlessworkflow/antora.yml
@@ -14,7 +14,6 @@ asciidoc:
     # upstream: remove this var
     #quarkus_cli_platform_redhat: -Pcom.redhat.quarkus.platform:quarkus-bom:2.7.6.Final-redhat-00006
     quarkus_cli_platform_redhat: ""
-    kogito_version: 2.0.0-SNAPSHOT
     # upstream: remove this var
     #kogito_version_redhat: 1.24.0.Final-redhat-00001
     kogito_version_redhat: ~

--- a/serverlessworkflow/antora.yml
+++ b/serverlessworkflow/antora.yml
@@ -14,6 +14,7 @@ asciidoc:
     # upstream: remove this var
     #quarkus_cli_platform_redhat: -Pcom.redhat.quarkus.platform:quarkus-bom:2.7.6.Final-redhat-00006
     quarkus_cli_platform_redhat: ""
+    kogito_version: 2.0.0-SNAPSHOT
     # upstream: remove this var
     #kogito_version_redhat: 1.24.0.Final-redhat-00001
     kogito_version_redhat: ~

--- a/serverlessworkflow/modules/ROOT/pages/cloud/deploying-on-minikube.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/deploying-on-minikube.adoc
@@ -299,7 +299,7 @@ curl -X POST -H 'Content-Type:application/json' -H 'Accept:application/json' -d 
 .Example response
 [source,json]
 ----
-{"id":"0f77abce-837e-4bd2-b4f1-a0e5e0265fcb","workflowdata":{"name":"John","language":"English","greeting":"Hello from JSON Workflow, "}}%
+{"id":"0f77abce-837e-4bd2-b4f1-a0e5e0265fcb","workflowdata":{"name":"John","language":"English","greeting":"Hello from JSON Workflow, "}}
 ----
 --
 

--- a/serverlessworkflow/modules/ROOT/pages/getting-started/create-your-first-workflow-service.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/getting-started/create-your-first-workflow-service.adoc
@@ -1,5 +1,11 @@
 = Creating your first workflow service
 
+:effective_kogito_version: {page-version}
+
+ifeval::["{quarkus_cli_platform_redhat}" != ""]
+:effective_kogito_version: {kogito_version_redhat}
+endif::[]
+
 As a developer, you can use {context} and create a `Hello World` application, which includes the following procedures:
 
 * <<proc-boostrapping-the-project,Bootstrapping a project>>
@@ -85,12 +91,13 @@ Knative CLI::
 +
 --
 .Create a project using Knative CLI
+
 [source,shell,subs="attributes"]
 ----
 kn workflow create \
   --name serverless-workflow-hello-world \
   --extension quarkus-jsonp,quarkus-smallrye-openapi \
-  --kogito-version={kogito_version} \
+  --kogito-version={effective_kogito_version} \
   --quarkus-version={quarkus_version}
 ----
 

--- a/serverlessworkflow/modules/ROOT/pages/getting-started/create-your-first-workflow-service.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/getting-started/create-your-first-workflow-service.adoc
@@ -356,7 +356,8 @@ Knative CLI::
 
 +
 --
-.Example request - Use the URL returned by the above command to access the deployed service.
+Use the URL returned by the previous command to access the deployed service:
+.Example request
 [source,shell]
 ----
 URL=$(kn service describe serverless-workflow-hello-world -o url) \

--- a/serverlessworkflow/modules/ROOT/pages/getting-started/create-your-first-workflow-service.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/getting-started/create-your-first-workflow-service.adoc
@@ -357,6 +357,7 @@ Knative CLI::
 +
 --
 Use the URL returned by the previous command to access the deployed service:
+
 .Example request
 [source,shell]
 ----

--- a/serverlessworkflow/modules/ROOT/pages/getting-started/create-your-first-workflow-service.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/getting-started/create-your-first-workflow-service.adoc
@@ -343,7 +343,7 @@ The returned URL must be used to access the deployed service.
 +
 [tabs]
 ====
-Quarkus CLI/Apache Maven::
+Quarkus CLI or Apache Maven::
 +
 --
 .Example request

--- a/serverlessworkflow/modules/ROOT/pages/getting-started/create-your-first-workflow-service.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/getting-started/create-your-first-workflow-service.adoc
@@ -175,11 +175,10 @@ xref:getting-started/cncf-serverless-workflow-specification-support.adoc[CNCF Se
 [[proc-building-application]]
 == Building your workflow application
 
-+
 ifeval::["{quarkus_cli_platform_redhat}" != ""]
 include::../../pages/_common-content/downstream-post-create-project.adoc[]
 endif::[]
-+
+
 . To verify that project is created, compile the project using the following command:
 +
 [tabs]

--- a/serverlessworkflow/modules/ROOT/pages/getting-started/create-your-first-workflow-service.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/getting-started/create-your-first-workflow-service.adoc
@@ -85,9 +85,9 @@ Knative CLI::
 +
 --
 .Create a project using Knative CLI
-[source,shell]
+[source,shell,subs="attributes"]
 ----
-kn workflow create --name my-project --extension quarkus-jsonp,quarkus-smallrye-openapi
+kn workflow create --name serverless-workflow-hello-world --extension quarkus-jsonp,quarkus-smallrye-openapi
 ----
 
 For more information about Knative CLI, see xref:tooling/kn-plugin-workflow-overview.adoc[{context} plug-in for Knative CLI].
@@ -123,11 +123,13 @@ mvn clean package
 Knative CLI::
 +
 --
-.Build your project and generate a local image called `quay.io/other-user/my-project:1.0.1`
+.Build your project and generate a local image called `dev.local/serverless-workflow-hello-world:latest`
 [source,shell]
 ----
-kn workflow build --image my-user/my-project:1.0.0 --image-repository other-user --image-tag 1.0.1
+kn workflow build --image dev.local/serverless-workflow-hello-world --verbose
 ----
+The `--verbose` flag is used to display the output of the build command. This flag is optional.
+
 For more information about Knative CLI, see xref:tooling/kn-plugin-workflow-overview.adoc[{context} plug-in for Knative CLI].
 --
 ====
@@ -245,6 +247,11 @@ kn workflow deploy
 For more information about Knative CLI, see xref:tooling/kn-plugin-workflow-overview.adoc[{context} plug-in for Knative CLI].
 --
 ====
+
++
+[tabs]
+====
+Quarkus CLI/Apache Maven::
 +
 .Example response
 [source,shell,subs="attributes"]
@@ -284,8 +291,40 @@ __  ____  __  _____   ___  __ ____  ______
 2022-05-25 14:38:13,379 INFO  [org.kie.kog.qua.pro.dev.DataIndexInMemoryContainer] (docker-java-stream--938264210) STDOUT: 2022-05-25 17:38:13,182 INFO  [io.quarkus] (main) Profile prod activated.
 2022-05-25 14:38:13,380 INFO  [org.kie.kog.qua.pro.dev.DataIndexInMemoryContainer] (docker-java-stream--938264210) STDOUT: 2022-05-25 17:38:13,182 INFO  [io.quarkus] (main) Installed features: [agroal, cdi, hibernate-orm, hibernate-orm-panache, inmemory-postgres, jdbc-postgresql, narayana-jta, oidc, reactive-routes, rest-client-reactive, rest-client-reactive-jackson, security, smallrye-context-propagation, smallrye-graphql-client, smallrye-health, smallrye-metrics, smallrye-reactive-messaging, smallrye-reactive-messaging-http, vertx, vertx-graphql]
 ----
+--
+Knative CLI::
++
+--
+.Example response
+[source,shell]
+----
+✅ Knative service sucessufully created
+🚀 Deploy took: 194.263309ms
+----
+
+.Check if your service is ready
+[source,shell]
+----
+kn service list
+----
+
+.Example response
+[source,shell]
+----
+NAME                              URL                                                                      LATEST                                  AGE   CONDITIONS   READY   REASON
+serverless-workflow-hello-world   http://serverless-workflow-hello-world.default.10.106.207.219.sslip.io   serverless-workflow-hello-world-00001   6s    3 OK / 3     True
+----
+
+The returned URL must be used to access the deployed service.
+--
+====
 
 . Once your workflow application is started, you can send a request for the provided endpoint:
+
++
+[tabs]
+====
+Quarkus CLI/Apache Maven::
 +
 --
 .Example request
@@ -293,7 +332,22 @@ __  ____  __  _____   ___  __ ____  ______
 ----
 curl -X POST -H 'Content-Type:application/json' http://localhost:8080/hello_world
 ----
+--
+Knative CLI::
 
++
+--
+.Example request - Use the URL returned by the above command to access the deployed service.
+[source,shell]
+----
+URL=$(kn service describe serverless-workflow-hello-world -o url) \
+  curl -X POST -H 'Content-Type:application/json' ${URL}/hello_world
+----
+--
+====
+
++
+--
 .Example response
 [source,shell]
 ----
@@ -301,7 +355,7 @@ curl -X POST -H 'Content-Type:application/json' http://localhost:8080/hello_worl
 ----
 --
 
-. You can update your workflow with a new `mantra` value without restarting the application.
+. When running in development mode (using Quarkus CLI or Apache Maven), you can update your workflow with a new `mantra` value without restarting the application.
 +
 --
 .Update your workflow

--- a/serverlessworkflow/modules/ROOT/pages/getting-started/create-your-first-workflow-service.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/getting-started/create-your-first-workflow-service.adoc
@@ -1,11 +1,5 @@
 = Creating your first workflow service
 
-:effective_kogito_version: {page-version}
-
-ifeval::["{quarkus_cli_platform_redhat}" != ""]
-:effective_kogito_version: {kogito_version_redhat}
-endif::[]
-
 As a developer, you can use {context} and create a `Hello World` application, which includes the following procedures:
 
 * <<proc-boostrapping-the-project,Bootstrapping a project>>
@@ -97,7 +91,7 @@ Knative CLI::
 kn workflow create \
   --name serverless-workflow-hello-world \
   --extension quarkus-jsonp,quarkus-smallrye-openapi \
-  --kogito-version={effective_kogito_version} \
+  --quarkus-platform-group-id={quarkus_platform}
   --quarkus-version={quarkus_version}
 ----
 

--- a/serverlessworkflow/modules/ROOT/pages/getting-started/create-your-first-workflow-service.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/getting-started/create-your-first-workflow-service.adoc
@@ -85,50 +85,14 @@ Knative CLI::
 +
 --
 .Create a project using Knative CLI
-[source,shell]
+[source,shell,subs="attributes"]
 ----
-kn workflow create --name serverless-workflow-hello-world --extension quarkus-jsonp,quarkus-smallrye-openapi
+kn workflow create \
+  --name serverless-workflow-hello-world \
+  --extension quarkus-jsonp,quarkus-smallrye-openapi \
+  --kogito-version={kogito_version} \
+  --quarkus-version={quarkus_version}
 ----
-
-For more information about Knative CLI, see xref:tooling/kn-plugin-workflow-overview.adoc[{context} plug-in for Knative CLI].
---
-====
-+
-ifeval::["{quarkus_cli_platform_redhat}" != ""]
-include::../../pages/_common-content/downstream-post-create-project.adoc[]
-endif::[]
-+
-. To verify that project is created, compile the project using the following command:
-+
-[tabs]
-====
-Quarkus CLI::
-+
---
-.Compile your project using Quarkus CLI
-[source,shell]
-----
-quarkus build
-----
---
-Apache Maven::
-+
---
-.Compile your project using Apache Maven
-[source,shell]
-----
-mvn clean package
-----
---
-Knative CLI::
-+
---
-.Build your project and generate a local image called `dev.local/serverless-workflow-hello-world:latest`
-[source,shell]
-----
-kn workflow build --image dev.local/serverless-workflow-hello-world --verbose
-----
-The `--verbose` flag is used to display the output of the build command. This flag is optional.
 
 For more information about Knative CLI, see xref:tooling/kn-plugin-workflow-overview.adoc[{context} plug-in for Knative CLI].
 --
@@ -206,6 +170,50 @@ The workflow definition follows the CNCF Serverless Workflow specification. For 
 xref:getting-started/cncf-serverless-workflow-specification-support.adoc[CNCF Serverless Workflow specification].
 ====
 --
+
+[[proc-building-application]]
+== Building your workflow application
+
++
+ifeval::["{quarkus_cli_platform_redhat}" != ""]
+include::../../pages/_common-content/downstream-post-create-project.adoc[]
+endif::[]
++
+. To verify that project is created, compile the project using the following command:
++
+[tabs]
+====
+Quarkus CLI::
++
+--
+.Compile your project using Quarkus CLI
+[source,shell]
+----
+quarkus build
+----
+--
+Apache Maven::
++
+--
+.Compile your project using Apache Maven
+[source,shell]
+----
+mvn clean package
+----
+--
+Knative CLI::
++
+--
+.Build your project and generate a local image called `dev.local/serverless-workflow-hello-world:latest`
+[source,shell]
+----
+kn workflow build --image dev.local/serverless-workflow-hello-world --verbose
+----
+The `--verbose` flag is used to display the output of the build command. This flag is optional.
+
+For more information about Knative CLI, see xref:tooling/kn-plugin-workflow-overview.adoc[{context} plug-in for Knative CLI].
+--
+====
 
 [[proc-running-application]]
 == Running your workflow application
@@ -291,10 +299,10 @@ __  ____  __  _____   ___  __ ____  ______
 2022-05-25 14:38:13,379 INFO  [org.kie.kog.qua.pro.dev.DataIndexInMemoryContainer] (docker-java-stream--938264210) STDOUT: 2022-05-25 17:38:13,182 INFO  [io.quarkus] (main) Profile prod activated.
 2022-05-25 14:38:13,380 INFO  [org.kie.kog.qua.pro.dev.DataIndexInMemoryContainer] (docker-java-stream--938264210) STDOUT: 2022-05-25 17:38:13,182 INFO  [io.quarkus] (main) Installed features: [agroal, cdi, hibernate-orm, hibernate-orm-panache, inmemory-postgres, jdbc-postgresql, narayana-jta, oidc, reactive-routes, rest-client-reactive, rest-client-reactive-jackson, security, smallrye-context-propagation, smallrye-graphql-client, smallrye-health, smallrye-metrics, smallrye-reactive-messaging, smallrye-reactive-messaging-http, vertx, vertx-graphql]
 ----
---
+
+
 Knative CLI::
 +
---
 .Example response
 [source,shell]
 ----
@@ -302,12 +310,14 @@ Knative CLI::
 🚀 Deploy took: 194.263309ms
 ----
 
++
 .Check if your service is ready
 [source,shell]
 ----
 kn service list
 ----
 
++
 .Example response
 [source,shell]
 ----
@@ -315,8 +325,9 @@ NAME                              URL                                           
 serverless-workflow-hello-world   http://serverless-workflow-hello-world.default.10.106.207.219.sslip.io   serverless-workflow-hello-world-00001   6s    3 OK / 3     True
 ----
 
++
 The returned URL must be used to access the deployed service.
---
+
 ====
 
 . Once your workflow application is started, you can send a request for the provided endpoint:

--- a/serverlessworkflow/modules/ROOT/pages/getting-started/create-your-first-workflow-service.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/getting-started/create-your-first-workflow-service.adoc
@@ -85,7 +85,7 @@ Knative CLI::
 +
 --
 .Create a project using Knative CLI
-[source,shell,subs="attributes"]
+[source,shell]
 ----
 kn workflow create --name serverless-workflow-hello-world --extension quarkus-jsonp,quarkus-smallrye-openapi
 ----

--- a/serverlessworkflow/modules/ROOT/pages/getting-started/create-your-first-workflow-service.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/getting-started/create-your-first-workflow-service.adoc
@@ -319,6 +319,7 @@ Knative CLI::
 
 +
 .Check if your service is ready
+.Verify Knative service
 [source,shell]
 ----
 kn service list

--- a/serverlessworkflow/modules/ROOT/pages/getting-started/create-your-first-workflow-service.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/getting-started/create-your-first-workflow-service.adoc
@@ -91,7 +91,7 @@ Knative CLI::
 kn workflow create \
   --name serverless-workflow-hello-world \
   --extension quarkus-jsonp,quarkus-smallrye-openapi \
-  --quarkus-platform-group-id={quarkus_platform}
+  --quarkus-platform-group-id={quarkus_platform} \
   --quarkus-version={quarkus_version}
 ----
 

--- a/serverlessworkflow/modules/ROOT/pages/getting-started/create-your-first-workflow-service.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/getting-started/create-your-first-workflow-service.adoc
@@ -266,7 +266,7 @@ For more information about Knative CLI, see xref:tooling/kn-plugin-workflow-over
 +
 [tabs]
 ====
-Quarkus CLI/Apache Maven::
+Quarkus CLI or Apache Maven::
 +
 .Example response
 [source,shell,subs="attributes"]

--- a/serverlessworkflow/modules/ROOT/pages/tooling/kn-plugin-workflow-overview.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/tooling/kn-plugin-workflow-overview.adoc
@@ -161,7 +161,6 @@ For more information about creating a workflow project, see <<proc-create-sw-pro
 [source,shell]
 ----
 kn workflow build --image dev.local/my-project
-kn workflow build --image-name dev.local/my-project
 ----
 
 [NOTE]

--- a/serverlessworkflow/modules/ROOT/pages/tooling/kn-plugin-workflow-overview.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/tooling/kn-plugin-workflow-overview.adoc
@@ -311,7 +311,7 @@ include::../../pages/_common-content/getting-started-requirement.adoc[]
 .Clone `kie-tools` repository
 [source,shell]
 ----
-git clone git@github.com:kie-group/kie-tools.git
+git clone git@github.com:kiegroup/kie-tools.git
 ----
 --
 

--- a/serverlessworkflow/modules/ROOT/pages/tooling/kn-plugin-workflow-overview.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/tooling/kn-plugin-workflow-overview.adoc
@@ -157,12 +157,17 @@ For more information about creating a workflow project, see <<proc-create-sw-pro
 . In Knative CLI, enter the following command to build your workflow project:
 +
 --
-.Build the project and generate a local image named `quay.io/my-project`
+.Build the project and generate a local image named `dev.local/my-project`
 [source,shell]
 ----
-kn workflow build --image my-project
-kn workflow build --image-name my-project
+kn workflow build --image dev.local/my-project
+kn workflow build --image-name dev.local/my-project
 ----
+
+[NOTE]
+====
+By using `dev.local` as repository, you can deploy your Serverless Workflow project in a local environment without having to push the image to a container registry.
+====
 
 To use the `build` command, you need to provide either `--image` or `--image-name` flag. In the previous command, you can use the `[-i|--image]` in several ways, such as:
 
@@ -209,14 +214,14 @@ You can use the following commands to build a workflow project and to generate a
 .Build a project and generate a local image using Jib
 [source,shell]
 ----
-kn workflow build --image my-project --jib
+kn workflow build --image dev.local/my-project --jib
 ----
 The generated container image can be saved in the Docker runtime.
 
 .Build a project and generate a local image using Jib
 [source,shell]
 ----
-kn workflow build --image my-project --jib-podman
+kn workflow build --image dev.local/my-project --jib-podman
 ----
 Using the previous command, the generated container image can be saved in the Podman runtime.
 

--- a/serverlessworkflow/modules/ROOT/pages/tooling/kn-plugin-workflow-overview.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/tooling/kn-plugin-workflow-overview.adoc
@@ -165,7 +165,7 @@ kn workflow build --image dev.local/my-project
 
 [NOTE]
 ====
-By using `dev.local` as repository, you can deploy your Serverless Workflow project in a local environment without having to push the image to a container registry.
+By using `dev.local` as repository, you can deploy your {context} project in a local environment without having to push the image to a container registry.
 ====
 
 To use the `build` command, you need to provide either `--image` or `--image-name` flag. In the previous command, you can use the `[-i|--image]` in several ways, such as:


### PR DESCRIPTION
**JIRA:** https://issues.redhat.com/browse/KOGITO-7694

* Fixed `kn` commands in the Getting Started guide
* Added quarkus and kogito versions to `kn workflow create` command
* Created a dedicated section for building the project after the "Creating a workflow" section
* Added `dev.local` as repository to `kn-plugin-workflow-overview.adoc` - @ljmotta can you review please?
* Fixed broken link in deploying-on-minikube.adoc

## Needs cherry-pick to:
- [x] 1.24.x - https://github.com/kiegroup/kogito-docs/pull/142
- [ ] 1.25.x
- [ ] 1.26.x

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributions doc](https://github.com/kiegroup/kogito-docs/blob/main/CONTRIBUTING.md)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [x] The nav.adoc file has a link to this guide in the proper category
- [x] The index.adoc file has a card to this guide in the proper category, with a meaningful description
