### PR TITLE
Fix Workflow plug-in version and Building from source section

### DIFF
--- a/serverlessworkflow/antora.yml
+++ b/serverlessworkflow/antora.yml
@@ -31,6 +31,9 @@ asciidoc:
     spec_version: 0.8
     vscode_version: 1.46.0
     kn-cli-version: 0.21.1
+    kie_tools_node_min_version: 16.13.2
+    kie_tools_pnpm_min_version: 7.0.0
+    kie_tools_golang_min_version: 1.19
     # only used in downstream
     kogito_devservices_imagename: registry.redhat.io/openshift-serverless-1-tech-preview/logic-data-index-ephemeral-rhel8
     kogito_examples_repository_url: https://github.com/kiegroup/kogito-examples
@@ -59,3 +62,6 @@ asciidoc:
     kubectl_install_url: https://kubernetes.io/docs/tasks/tools/install-kubectl
     kn_cli_install_url: https://github.com/knative/client/blob/main/docs/README.md#installing-kn
     kafka_doc_url: https://kafka.apache.org/documentation/
+    node_install_url: https://nodejs.org/en/download/package-manager/
+    pnpm_install_url: https://pnpm.io/installation
+    golang_install_url: https://go.dev/doc/install

--- a/serverlessworkflow/antora.yml
+++ b/serverlessworkflow/antora.yml
@@ -30,7 +30,7 @@ asciidoc:
     graalvm_min_version: 22.1.0
     spec_version: 0.8
     vscode_version: 1.46.0
-    kn-cli-version: 0.21.1
+    kn_cli_version: 0.21.3
     kie_tools_node_min_version: 16.13.2
     kie_tools_pnpm_min_version: 7.0.0
     kie_tools_golang_min_version: 1.19

--- a/serverlessworkflow/modules/ROOT/pages/getting-started/create-your-first-workflow-service.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/getting-started/create-your-first-workflow-service.adoc
@@ -20,7 +20,7 @@ image::getting-started/hello-world-workflow.png[]
 .Prerequisites
 * Java {java_min_version} is installed with `JAVA_HOME` configured appropriately.
 * Apache Maven {maven_min_version} is installed.
-* {quarkus_cli_url}[Quarkus CLI] {quarkus_version} or xref:tooling/kn-plugin-workflow-overview.adoc[Knative CLI] {kn-cli-version} is installed.
+* {quarkus_cli_url}[Quarkus CLI] {quarkus_version} or xref:tooling/kn-plugin-workflow-overview.adoc[Knative CLI] {kn_cli_version} is installed.
 * Visual Studio Code with https://marketplace.visualstudio.com/items?itemName=redhat.java[Red Hat Java Extension]
 and https://marketplace.visualstudio.com/items?itemName=redhat.vscode-extension-serverless-workflow-editor[Red Hat Serverless Workflow Editor] is installed to edit your workflows.
 

--- a/serverlessworkflow/modules/ROOT/pages/tooling/kn-plugin-workflow-overview.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/tooling/kn-plugin-workflow-overview.adoc
@@ -293,7 +293,7 @@ You can use the `kubectl` command line if you want to use a complex deployment s
 --
 
 [[proc-build-sw-project-source]]
-== Build from source
+== Building from source
 
 As an alternative, you can build the Workflow plug-in from source.
 
@@ -316,7 +316,7 @@ git clone git@github.com:kiegroup/kie-tools.git
 . Navigate to the cloned `kie-tools` directory and enter the following command to install the dependencies and link the repository packages:
 +
 --
-.Access {context} plug-in
+.Navigate to the repository, install dependencies, and link packages
 [source,shell]
 ----
 cd kie-tools
@@ -327,7 +327,7 @@ pnpm bootstrap
 . In the repository root, enter the following command to build the Workflow plug-in:
 +
 --
-.Build workflow project from source
+.Build Workflow plug-in from source
 [source,shell]
 ----
 pnpm -r -F kn-plugin-workflow... build:dev

--- a/serverlessworkflow/modules/ROOT/pages/tooling/kn-plugin-workflow-overview.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/tooling/kn-plugin-workflow-overview.adoc
@@ -293,12 +293,14 @@ You can use the `kubectl` command line if you want to use a complex deployment s
 --
 
 [[proc-build-sw-project-source]]
-== Building a workflow project from source
+== Build from source
 
-As an alternative, you can build your workflow project from source.
+As an alternative, you can build the Workflow plug-in from source.
 
 .Prerequisites
-include::../../pages/_common-content/getting-started-requirement.adoc[]
+* link:{node_install_url}[Node] {kie_tools_node_min_version} or later is installed.
+* link:{pnpm_install_url}[pnpm] {kie_tools_pnpm_min_version} or later is installed.
+* link:{golang_install_url}[Go] {kie_tools_golang_min_version} or later is installed.
 
 .Procedure
 . In a command terminal, enter the following command to clone the `kie-tools` GitHub repository:
@@ -307,11 +309,11 @@ include::../../pages/_common-content/getting-started-requirement.adoc[]
 .Clone `kie-tools` repository
 [source,shell]
 ----
-git clone git@github.com:kie-group/kie-tools.git
+git clone git@github.com:kiegroup/kie-tools.git
 ----
 --
 
-. Navigate to the cloned `kie-tools` directory and enter the following command to access the {context} plug-in:
+. Navigate to the cloned `kie-tools` directory and enter the following command to install the dependencies and link the repository packages:
 +
 --
 .Access {context} plug-in
@@ -319,22 +321,20 @@ git clone git@github.com:kie-group/kie-tools.git
 ----
 cd kie-tools
 pnpm bootstrap
-pnpm -F @kie-tools/kn-plugin-workflow... build:dev
 ----
 --
 
-. Go to the plug-in folder and enter the following command to build the workflow project:
+. In the repository root, enter the following command to build the Workflow plug-in:
 +
 --
 .Build workflow project from source
 [source,shell]
 ----
-cd packages/kn-plugin-workflow
-go mod tidy
+pnpm -r -F kn-plugin-workflow... build:dev
 ----
 --
 
-You have successfully built your workflow project from source.
+You have successfully built the Workflow plug-in project from source. This _Procedure_ generates an artifact compatible with your OS architecture in the `kie-tools/packages/kn-plugin-workflow/dist` folder.
 
 == Additional resources
 

--- a/serverlessworkflow/modules/ROOT/pages/tooling/kn-plugin-workflow-overview.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/tooling/kn-plugin-workflow-overview.adoc
@@ -299,7 +299,7 @@ You can use the `kubectl` command line if you want to use a complex deployment s
 [[proc-build-sw-project-source]]
 == Building from source
 
-As an alternative, you can build the Workflow plug-in from source.
+As an alternative, you can build the workflow plug-in from the source.
 
 .Prerequisites
 * link:{node_install_url}[Node] {kie_tools_node_min_version} or later is installed.
@@ -328,17 +328,17 @@ pnpm bootstrap
 ----
 --
 
-. In the repository root, enter the following command to build the Workflow plug-in:
+. In the repository root, enter the following command to build the workflow plug-in:
 +
 --
-.Build Workflow plug-in from source
+.Build workflow plug-in from source
 [source,shell]
 ----
 pnpm -r -F kn-plugin-workflow... build:dev
 ----
 --
 
-You have successfully built the Workflow plug-in project from source. This _Procedure_ generates an artifact compatible with your OS architecture in the `kie-tools/packages/kn-plugin-workflow/dist` folder.
+You have successfully built the workflow plug-in project from the source. This procedure generates an artifact compatible with your operating system architecture in the `kie-tools/packages/kn-plugin-workflow/dist` folder.
 
 == Additional resources
 


### PR DESCRIPTION
This PR updates the kn_cli_version to 0.21.3 (release in progress), and updates the Building from source section.

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributions doc](https://github.com/kiegroup/kogito-docs/blob/main/CONTRIBUTING.md)
- [ ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [ ] The nav.adoc file has a link to this guide in the proper category
- [ ] The index.adoc file has a card to this guide in the proper category, with a meaningful description
