### PR TITLE
Use correct Quarkus downstream and KN CLI version

### DIFF
--- a/serverlessworkflow/antora.yml
+++ b/serverlessworkflow/antora.yml
@@ -25,14 +25,14 @@ asciidoc:
     # upstream: kogito-quarkus-serverless-workflow
     # kogito_sw_ga: org.kie.kogito:kogito-quarkus-serverless-workflow
     kogito_sw_ga: kogito-quarkus-serverless-workflow
-    # downstream: 2.7.6.Final-redhat-00011
+    # downstream: 2.7.6.Final-redhat-00006
     quarkus_version: 2.11.2.Final
     java_min_version: 11+
     maven_min_version: 3.8.6
     graalvm_min_version: 22.1.0
     spec_version: 0.8
     vscode_version: 1.46.0
-    kn-cli-version: 0.21.1
+    kn-cli-version: 0.21.2
     # only used in downstream
     kogito_devservices_imagename: registry.redhat.io/openshift-serverless-1-tech-preview/logic-data-index-ephemeral-rhel8
     kogito_examples_repository_url: https://github.com/kiegroup/kogito-examples


### PR DESCRIPTION
Just a backport of changes made by @jstastny-cz on 1.24.x, 1.25.x and 1.26.x branches.

See https://github.com/kiegroup/kogito-docs/pull/145