### PR TITLE
[KOGITO-7767] - Fix Maven instructions to add earlyaccess config

### DIFF
--- a/serverlessworkflow/antora.yml
+++ b/serverlessworkflow/antora.yml
@@ -13,12 +13,9 @@ asciidoc:
     product_name: Kogito
     #in Downstream context: OpenShift Serverless Logic
     context: Serverless Workflow
-    # upstream: remove this var
-    #quarkus_cli_platform_redhat: -Pcom.redhat.quarkus.platform:quarkus-bom:2.7.6.Final-redhat-00006
-    quarkus_cli_platform_redhat: ""
-    # upstream: remove this var
+    # upstream: empty
     #kogito_version_redhat: 1.24.0.Final-redhat-00001
-    kogito_version_redhat: ~
+    kogito_version_redhat: ""
     # upstream: io.quarkus.platform
     #quarkus_platform: com.redhat.quarkus.platform
     quarkus_platform: io.quarkus.platform

--- a/serverlessworkflow/modules/ROOT/pages/_common-content/downstream-project-setup-instructions.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/_common-content/downstream-project-setup-instructions.adoc
@@ -12,8 +12,9 @@ To use the Red Hat Build of Quarkus (RHBQ) libraries, you need to configure your
 .Procedure
 . To configure the Apache Maven `settings.xml` file and Quarkus extension registry client, follow the instructions in the link:{rhbq_config_maven_url}[Configuring the Maven settings.xml file for the online repository] and link:{rhbq_config_registry_url}[Configuring Quarkus extension registry client].
 +
-. Complement the Apache Maven `settings.xml` file that you configured in the last step with the following profile to have access to the {product_name} repository:
+. Complement the configured Apache Maven `settings.xml` file with the following profile to have access to the {product_name} repository:
 +
+.Profile to access the {product_name} repository
 [source,xml,subs="attributes+"]
 ----
 <!-- Configure the {product_name} Maven repository -->

--- a/serverlessworkflow/modules/ROOT/pages/_common-content/downstream-project-setup-instructions.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/_common-content/downstream-project-setup-instructions.adoc
@@ -12,4 +12,41 @@ To use the Red Hat Build of Quarkus (RHBQ) libraries, you need to configure your
 .Procedure
 . To configure the Apache Maven `settings.xml` file and Quarkus extension registry client, follow the instructions in the link:{rhbq_config_maven_url}[Configuring the Maven settings.xml file for the online repository] and link:{rhbq_config_registry_url}[Configuring Quarkus extension registry client].
 +
+. Complement the Apache Maven `settings.xml` file that you configured in the last step with the following profile to have access to the {product_name} repository:
++
+[source,xml,subs="attributes+"]
+----
+<!-- Configure the {product_name} Maven repository -->
+<profile>
+  <id>red-hat-earlyaccess-maven-repository</id>
+  <activation>
+    <activeByDefault>true</activeByDefault>
+  </activation>
+  <repositories>
+    <repository>
+      <id>red-hat-earlyaccess-maven-repository</id>
+      <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>red-hat-earlyaccess-maven-repository</id>
+      <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </pluginRepository>
+  </pluginRepositories>
+</profile>
+----
++
 . Follow the instructions in the link:{redhat_registry_auth_url}[Red Hat Container Registry Authentication] article to log in to the registry and use the {context} images locally.

--- a/serverlessworkflow/modules/ROOT/pages/getting-started/create-your-first-workflow-service.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/getting-started/create-your-first-workflow-service.adoc
@@ -20,13 +20,13 @@ image::getting-started/hello-world-workflow.png[]
 .Prerequisites
 * Java {java_min_version} is installed with `JAVA_HOME` configured appropriately.
 * Apache Maven {maven_min_version} is installed.
-* {quarkus_cli_url}[Quarkus CLI] {quarkus_version} or xref:tooling/kn-plugin-workflow-overview.adoc[Knative CLI] {kn-cli-version} is installed.
+* {quarkus_cli_url}[Quarkus CLI] or xref:tooling/kn-plugin-workflow-overview.adoc[Knative CLI] {kn-cli-version} is installed.
 * Visual Studio Code with https://marketplace.visualstudio.com/items?itemName=redhat.java[Red Hat Java Extension]
 and https://marketplace.visualstudio.com/items?itemName=redhat.vscode-extension-serverless-workflow-editor[Red Hat Serverless Workflow Editor] is installed to edit your workflows.
 
 For more information about the tooling and the required dependencies, see xref:getting-started/getting-familiar-with-our-tooling.adoc[Getting familiar with {context} tooling].
 
-ifeval::["{quarkus_cli_platform_redhat}" != ""]
+ifeval::["{kogito_version_redhat}" != ""]
 include::../../pages/_common-content/downstream-project-setup-instructions.adoc[]
 endif::[]
 
@@ -51,7 +51,7 @@ quarkus create app \
     -x=quarkus-container-image-jib \
     -x=quarkus-resteasy-jackson \
     -x=quarkus-smallrye-openapi \
-    --no-code {quarkus_cli_platform_redhat} \
+    --no-code \
     org.kie.kogito.examples:serverless-workflow-hello-world:1.0
 ----
 
@@ -175,7 +175,7 @@ xref:getting-started/cncf-serverless-workflow-specification-support.adoc[CNCF Se
 [[proc-building-application]]
 == Building your workflow application
 
-ifeval::["{quarkus_cli_platform_redhat}" != ""]
+ifeval::["{kogito_version_redhat}" != ""]
 include::../../pages/_common-content/downstream-post-create-project.adoc[]
 endif::[]
 

--- a/serverlessworkflow/modules/ROOT/pages/getting-started/create-your-first-workflow-service.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/getting-started/create-your-first-workflow-service.adoc
@@ -20,7 +20,7 @@ image::getting-started/hello-world-workflow.png[]
 .Prerequisites
 * Java {java_min_version} is installed with `JAVA_HOME` configured appropriately.
 * Apache Maven {maven_min_version} is installed.
-* {quarkus_cli_url}[Quarkus CLI] or xref:tooling/kn-plugin-workflow-overview.adoc[Knative CLI] {kn-cli-version} is installed.
+* {quarkus_cli_url}[Quarkus CLI] or xref:tooling/kn-plugin-workflow-overview.adoc[Knative Workflow CLI] {kn-cli-version} is installed.
 * Visual Studio Code with https://marketplace.visualstudio.com/items?itemName=redhat.java[Red Hat Java Extension]
 and https://marketplace.visualstudio.com/items?itemName=redhat.vscode-extension-serverless-workflow-editor[Red Hat Serverless Workflow Editor] is installed to edit your workflows.
 

--- a/serverlessworkflow/modules/ROOT/pages/tooling/kn-plugin-workflow-overview.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/tooling/kn-plugin-workflow-overview.adoc
@@ -97,7 +97,7 @@ The `create` command sets up Quarkus project containing minimal extensions to bu
 * {context} plug-in for Knative CLI is installed.
 +
 For more information about installing the plug-in, see <<proc-install-sw-plugin-kn-cli, Installing the {context} plug-in for Knative CLI>>.
-ifeval::["{quarkus_cli_platform_redhat}" != ""]
+ifeval::["{kogito_version_redhat}" != ""]
 * You followed the steps in xref:getting-started/create-your-first-workflow-service.adoc#proc-configuring-maven-rhbq[Configuring your Maven project to Red Hat build of Quarkus and OpenShift Serverless Logic]
 endif::[]
 


### PR DESCRIPTION
Signed-off-by: Ricardo Zanini <zanini@redhat.com>

<!-- Please don't forget your JIRA link -->
**JIRA:** https://issues.redhat.com/browse/KOGITO-7767

<!-- If you don't have a JIRA link, please provide a short description of what this PR does -->
**Description:** Include our early access maven repo to the settings.xml, remove unused var, and the `-P` flag from quarkus CLI command.-P

<!-- Link to related PRs: -->

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributions doc](https://github.com/kiegroup/kogito-docs/blob/main/CONTRIBUTING.md)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [ ] The nav.adoc file has a link to this guide in the proper category
- [ ] The index.adoc file has a card to this guide in the proper category, with a meaningful description
