### PR TITLE
KOGITO-7260: Patch PR for KOGITO-7250 with doc improvements in input schema guide

### DIFF
--- a/serverlessworkflow/modules/ROOT/nav.adoc
+++ b/serverlessworkflow/modules/ROOT/nav.adoc
@@ -9,7 +9,7 @@
 ** xref:core/working-with-parallelism.adoc[Parallelism in {context}]
 ** xref:core/configuration-properties.adoc[Configuration properties in {context}]
 //** xref:core/accessing-workflow-metainformation-in-runtime.adoc[Accessing workflow metainformation in runtime]
-** xref:core/defining-an-input-schema-for-workflows.adoc[Defining an input schema for {context}]
+** xref:core/defining-an-input-schema-for-workflows.adoc[Input schema definition for {context}]
 ** xref:core/custom-functions-support.adoc[Custom functions for your {context} service]
 * Tooling
 ** xref:tooling/serverless-workflow-editor/swf-editor-overview.adoc[Serverless Workflow editor]

--- a/serverlessworkflow/modules/ROOT/pages/core/defining-an-input-schema-for-workflows.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/core/defining-an-input-schema-for-workflows.adoc
@@ -1,14 +1,14 @@
-= Defining an input schema for {context}
+= Input schema definition for {context}
 :compat-mode!:
 // Metadata:
 :description: Defining input schema for Serverless Workflow
 :keywords: kogito, workflow, serverless, dataInputSchema
 
-The dataInputSchema in the link:{spec_doc_url}#workflow-definition-structure[Serverless Workflow specification] is one of the parameters in the Workflow definition.
+The `dataInputSchema` in the link:{spec_doc_url}#workflow-definition-structure[Serverless Workflow specification] is a parameter used in the workflow definition. The `dataInputSchema` parameter validates the workflow data input against a defined JSON Schema. It is important to provide `dataInputSchema`, as it is used to verify if the provided workflow data input is correct before any workflow states are executed.
 
-The dataInputSchema parameter is used to validate the workflow data input against a defined JSON Schema. It is important to provide a dataInputSchema, as it can be used to check if the provided workflow data input is a right one before any states are executed.
+You can define a `dataInputSchema` as follows:
 
-The dataInputSchema can be defined as follows:
+.`dataInputSchema` definition
 [source,json]
 ----
 "dataInputSchema": {
@@ -17,17 +17,13 @@ The dataInputSchema can be defined as follows:
 }
 ----
 
-"schema" property is an URI, which holds the path to the JSON schema used to validate the workflow data input. The URI can be a classpath URI, a file or a http.If a classpath URI is specified, the JSON schema file should be placed in the resources section of the project.
+In the previous definition, the `schema` property is a URI, which holds the path to the JSON schema used to validate the workflow data input. The URI can be a classpath URI, a file, or an HTTP. If a classpath URI is specified, then the JSON schema file must be placed in the resources section of the project.
 
-An example for a workflow definition with datainputschema can be found here- link:{kogito_sw_examples_url}/serverless-workflow-expression-quarkus/src/main/resources/expression.sw.json[`serverless-workflow-expression-quarkus`]
+You can see the link:{kogito_sw_examples_url}/serverless-workflow-expression-quarkus/src/main/resources/expression.sw.json[`serverless-workflow-expression-quarkus`] example application of a workflow definition with `dataInputSchema`. Also, for information about sample JSON schema, see link:{kogito_sw_examples_url}/src/main/resources/schema/expression.json[`serverless-workflow-expression-quarkus-json`].
 
-You can find a sample JSON schema here- link:{kogito_sw_examples_url}/src/main/resources/schema/expression.json[`serverless-workflow-expression-quarkus-json`]
+When a workflow definition contains a `dataInputSchema` attribute, the workflow application generates an OpenAPI file, such as `http://localhost/q/swagger-ui`. The generated OpenAPI file references the schema file, which helps in defining the input data for the workflows. For more information about OpenAPI file, see link:{open_api_spec_url}[OpenAPI specification].
 
-When a workflow definition has a dataInputSchema attribute defined, the application should generate an OpenAPI file (http://localhost/q/swagger-ui) referencing this schema file, which helps to correctly define the input data for the workflows.
-
-This documents describes about link:{open_api_spec_url}[OpenAPI] specification file.
-
-To generate an OpenAPI file for a Kogito Serverless workflow, the link:{quarkus_swagger_url}#expose-openapi-specifications[Quarkus dependency] must be added in the project.
+If you want to generate an OpenAPI file for a workflow, then you must add the link:{quarkus_swagger_url}#expose-openapi-specifications[Quarkus dependency] in the project. 
 
 .Example component section with schema in an OpenAPI file
 [source,yaml]
@@ -43,4 +39,5 @@ components:
         message:
           type: string
 ----
-[source,yaml]
+
+include::../../pages/_common-content/report-issue.adoc[]

--- a/serverlessworkflow/modules/ROOT/pages/core/defining-an-input-schema-for-workflows.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/core/defining-an-input-schema-for-workflows.adoc
@@ -40,4 +40,9 @@ components:
           type: string
 ----
 
+== Additional resources
+
+* xref:service-orchestration/orchestration-of-openapi-based-services.adoc[Orchestrating the OpenAPI services]
+* xref:service-orchestration/configuring-openapi-services-endpoints.adoc[Configuring the OpenAPI services endpoints]
+
 include::../../pages/_common-content/report-issue.adoc[]

--- a/serverlessworkflow/modules/ROOT/pages/index.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/index.adoc
@@ -73,9 +73,9 @@ Quick reference of configuration properties in workflow
 [.card]
 --
 [.card-title]
-xref:core/defining-an-input-schema-for-workflows.adoc[Defining an input schema for {context}]
+xref:core/defining-an-input-schema-for-workflows.adoc[Input schema definition for {context}]
 [.card-description]
-Learn how to define an input schema to validate the workflow data input against a defined JSON Schema
+Learn about the input schema definition used to validate the workflow data input against a defined JSON Schema
 --
 
 [.card-section]


### PR DESCRIPTION

<!-- Please don't forget your JIRA link -->
**JIRA:** https://issues.redhat.com/browse/KOGITO-7260

<!-- If you don't have a JIRA link, please provide a short description of what this PR does -->
**Description:** Patch PR for KOGITO-7250 with doc improvements in input schema guide

<!-- Link to related PRs: -->
https://github.com/kiegroup/kogito-docs/pull/151

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributions doc](https://github.com/kiegroup/kogito-docs/blob/main/CONTRIBUTING.md)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [x] The nav.adoc file has a link to this guide in the proper category
- [x] The index.adoc file has a card to this guide in the proper category, with a meaningful description

<details>
<summary>
How to setup automatic cherry-pick to another branch ?
</summary>

The cherry-pick action allows to setup automatic cherry-pick from `main` to a specific branch.

To allow it, you will need to add the corresponding label with pattern: `backport-{RELEASE_BRANCH}`.  
For example, if a backport to branch `1.26.x` is needed, then the label should be `backport-1.26.x`.

Once the PR is merged, the action will retrieve the commit and cherry-pick it to the desired branch.

*NOTE: You can still add label after the merge and it should still be cherry-picked.*
</details>