### PR TITLE
[1.26.x] KOGITO-7715 Pipelines: setup init job (#122)

### DIFF
--- a/.ci/jenkins/Jenkinsfile.init
+++ b/.ci/jenkins/Jenkinsfile.init
@@ -36,9 +36,9 @@ pipeline {
                         currentBuild.displayName = params.DISPLAY_NAME
                     }
 
-                    // Verify version is set and if on right release branch
-                    assert getKogitoVersion()
-                    assert getBuildBranch() == util.getReleaseBranchFromVersion(getKogitoVersion())
+                    if (getBuildBranch().split("\\.").length != 3) {
+                        error "Build branch name '${getBuildBranch()}' is in the wrong format. It should be X.Y.x"
+                    }
                 }
             }
         }
@@ -51,27 +51,61 @@ pipeline {
                         checkout(githubscm.resolveRepository('kogito-docs', getGitAuthor(), getBuildBranch(), false, getGitAuthorCredsID()))
                         sh "git checkout ${getBuildBranch()}"
 
+                        String[] branchSplit = getBuildBranch().split("\\.")
+                        String displayVersion = "${branchSplit[0]}.${branchSplit[1]}-RC"
+                        String version = "${branchSplit[0]}.${branchSplit[1]}.0-SNAPSHOT"
+                        String prereleaseStr = 'rc'
+                        String swExamplesURL = "https://github.com/kiegroup/kogito-examples/tree/${getBuildBranch()}/serverless-workflow-examples"
                         String antoraFile = 'serverlessworkflow/antora.yml'
+
                         sh """
-                            sed -i 's|^version:.*|version: ${getKogitoVersion()}|g' ${antoraFile}
-                            sed -i 's|^prerelease:.*||g' ${antoraFile}
+                            sed -i 's|^version:.*|version: ${version}|g' ${antoraFile}
+                            sed -i 's|^display_version:.*|display_version: ${displayVersion}|g' ${antoraFile}
+                            sed -i 's|^prerelease:.*|prerelease: ${prereleaseStr}|g' ${antoraFile}
+                            sed -i 's|kogito_sw_examples_url:.*|kogito_sw_examples_url: ${swExamplesURL}|g' ${antoraFile}
                         """
 
                         // Add changed files, commit, open and merge PR
                         if (githubscm.isThereAnyChanges()) {
-                            githubscm.commitChanges("Release Kogito ${getKogitoVersion()}")
+                            githubscm.commitChanges("Init ${getBuildBranch()} branch")
                             githubscm.pushObject('origin', getBuildBranch(), getGitAuthorCredsID())
                         } else {
-                            echo "No changes to push."
+                            echo 'No changes to push.'
                         }
-
-                        // Tag repository
-                        githubscm.tagLocalAndRemoteRepository('origin', getKogitoVersion(), getGitAuthorCredsID(), env.BUILD_TAG, true)
                     }
                 }
             }
         }
+
+        stage('Update Kogito Docs main branch') {
+            steps {
+                script {
+                    dir('kogito-docs') {
+                        deleteDir()
+                        checkout(githubscm.resolveRepository('kogito-docs', getGitAuthor(), 'main', false, getGitAuthorCredsID()))
+                        sh 'git checkout main'
+
+                        updateYaml('antora-playbook.yml') { antoraConfig ->
+                            if (!antoraConfig.content.sources[0].branches) {
+                                antoraConfig.content.sources[0].branches = []
+                            }
+                            if (!antoraConfig.content.sources[0].branches.find { it == getBuildBranch() }) {
+                                antoraConfig.content.sources[0].branches.add(getBuildBranch())
+                        }
+                    }
+
+                        // Add changed files, commit, open and merge PR
+                        if (githubscm.isThereAnyChanges()) {
+                            githubscm.commitChanges("Add branch ${getBuildBranch()} for generation")
+                            githubscm.pushObject('origin', 'main', getGitAuthorCredsID())
+                        } else {
+                            echo 'No changes to push.'
+                        }
+                }
+            }
+        }
     }
+}
     post {
         unsuccessful {
             sendNotification()

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -14,6 +14,7 @@ import org.kie.jenkins.jobdsl.KogitoJobUtils
 
 jenkins_path = '.ci/jenkins'
 
+setupInitJob()
 setupPostReleaseJob()
 
 KogitoJobUtils.createQuarkusUpdateToolsJob(this, 'kogito-docs', [:], [:], [[
@@ -24,6 +25,26 @@ KogitoJobUtils.createQuarkusUpdateToolsJob(this, 'kogito-docs', [:], [:], [[
 /////////////////////////////////////////////////////////////////
 // Methods
 /////////////////////////////////////////////////////////////////
+
+void setupInitJob() {
+    def jobParams = KogitoJobUtils.getBasicJobParams(this, 'kogito-docs', Folder.INIT, "${jenkins_path}/Jenkinsfile.init", 'Kogito Docs Branch init job')
+    jobParams.env.putAll([
+        JENKINS_EMAIL_CREDS_ID: "${JENKINS_EMAIL_CREDS_ID}",
+
+        GIT_AUTHOR: "${GIT_AUTHOR_NAME}",
+
+        AUTHOR_CREDS_ID: "${GIT_AUTHOR_CREDENTIALS_ID}",
+    ])
+    KogitoJobTemplate.createPipelineJob(this, jobParams)?.with {
+        parameters {
+            stringParam('DISPLAY_NAME', '', 'Setup a specific build display name')
+
+            stringParam('BUILD_BRANCH_NAME', "${GIT_BRANCH}", 'Set the Git branch to checkout')
+
+            booleanParam('SEND_NOTIFICATION', true, 'In case you want the pipeline to send a notification on CI channel for this run.')
+        }
+    }
+}
 
 void setupPostReleaseJob() {
     def jobParams = KogitoJobUtils.getBasicJobParams(this, 'kogito-docs-post-release', Folder.RELEASE, "${jenkins_path}/Jenkinsfile.post-release", 'Kogito Docs Post Release')


### PR DESCRIPTION
chery-pick: https://github.com/kiegroup/kogito-docs/pull/122

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributions doc](https://github.com/kiegroup/kogito-docs/blob/main/CONTRIBUTING.md)
- [ ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [ ] The nav.adoc file has a link to this guide in the proper category
- [ ] The index.adoc file has a card to this guide in the proper category, with a meaningful description

<details>
<summary>
How to setup automatic cherry-pick to another branch ?
</summary>

The cherry-pick action allows to setup automatic cherry-pick from `main` to a specific branch.

To allow it, you will need to add the corresponding label with pattern: `backport-{RELEASE_BRANCH}`.  
For example, if a backport to branch `1.26.x` is needed, then the label should be `backport-1.26.x`.

Once the PR is merged, the action will retrieve the commit and cherry-pick it to the desired branch.

*NOTE: You can still add label after the merge and it should still be cherry-picked.*
</details>