### PR TITLE
Add Release notes for 1.26 and contrib guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -223,7 +223,7 @@ project = Kogito and fixVersion = <version> and component in (Serverless) and ty
 Replace `<version>` with the given version, for example `1.26.0.Final`.
 
 2. Update the page [release_notes.adoc](serverlessworkflow/modules/ROOT/pages/release_notes.adoc)
-3. Align with the team what should be under "Notable chnages"
+3. Align with the team what should be under "Notable changes"
 4. Add the rest to "Other Changes and Bug Fixing".
 
 ## Useful Resources

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -212,6 +212,20 @@ Similarly you can have other admonitions:
 
 More details at [Antora documentation](https://docs.antora.org/antora/latest/asciidoc/admonitions/).
 
+## Generating Release Notes for Serverless Workflow
+
+1. Use the JIRA to search for the issues with:
+
+```
+project = Kogito and fixVersion = <version> and component in (Serverless) and type != Sub-task and type != Epic
+```
+
+Replace `<version>` with the given version, for example `1.26.0.Final`.
+
+2. Update the page [release_notes.adoc](serverlessworkflow/modules/ROOT/pages/release_notes.adoc)
+3. Align with the team what should be under "Notable chnages"
+4. Add the rest to "Other Changes and Bug Fixing".
+
 ## Useful Resources
 
 - [AsciiDoc Syntax Quick Reference](https://docs.asciidoctor.org/asciidoc/latest/syntax-quick-reference/)

--- a/serverlessworkflow/modules/ROOT/nav.adoc
+++ b/serverlessworkflow/modules/ROOT/nav.adoc
@@ -1,5 +1,5 @@
 // * xref:index.adoc[Home]
-* xref:release_notes.adoc[What's new]
+* xref:release_notes.adoc[Release notes for {context}]
 * Getting Started
 ** xref:getting-started/create-your-first-workflow-service.adoc[Creating your first workflow service]
 ** xref:getting-started/cncf-serverless-workflow-specification-support.adoc[CNCF Serverless Workflow specification]

--- a/serverlessworkflow/modules/ROOT/nav.adoc
+++ b/serverlessworkflow/modules/ROOT/nav.adoc
@@ -1,4 +1,5 @@
 // * xref:index.adoc[Home]
+* xref:release_notes.adoc[What's new]
 * Getting Started
 ** xref:getting-started/create-your-first-workflow-service.adoc[Creating your first workflow service]
 ** xref:getting-started/cncf-serverless-workflow-specification-support.adoc[CNCF Serverless Workflow specification]

--- a/serverlessworkflow/modules/ROOT/pages/release_notes.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/release_notes.adoc
@@ -1,0 +1,21 @@
+= What's new on {page-component-display-version}
+:compat-mode!:
+
+== Notable Changes
+
+. link:https://issues.redhat.com/browse/KOGITO-7620[KOGITO-7620] - Improve events consumption thread pools configs
+. link:https://issues.redhat.com/browse/KOGITO-7612[KOGITO-7612] - Implement gRPC streaming scenarios
+. link:https://issues.redhat.com/browse/KOGITO-7538[KOGITO-7538] - gRPC enum behaviour
+
+== Other Changes and Bug Fixing
+
+. link:https://issues.redhat.com/browse/KOGITO-7761[KOGITO-7761] - Kogito SW Guides latest version are pointing to main branch
+. link:https://issues.redhat.com/browse/KOGITO-7708[KOGITO-7708] - A few missing references and attributes are missing from the guides
+. link:https://issues.redhat.com/browse/KOGITO-7694[KOGITO-7694] - [KSW Guides] KN CLI generates project with different name and extensions than other options
+. link:https://issues.redhat.com/browse/KOGITO-7687[KOGITO-7687] - [KSW-Guides] - Restructure the guides to fit downstream structure
+. link:https://issues.redhat.com/browse/KOGITO-7636[KOGITO-7636] - [KSW-Guides] SW configuration properties guide
+. link:https://issues.redhat.com/browse/KOGITO-7611[KOGITO-7611] - Remove test-utils from the SW examples and replace by Dev Services
+. link:https://issues.redhat.com/browse/KOGITO-7610[KOGITO-7610] - [KSW-Guides] - Add How-To use RHBQ and Kogito productized artifacts
+. link:https://issues.redhat.com/browse/KOGITO-7309[KOGITO-7309] - [KSW-Guides] Integration tests with PostgreSQL
+. link:https://issues.redhat.com/browse/KOGITO-7301[KOGITO-7301] - [KSW-Guides] Persistence with PostgresSQL databases
+. link:https://issues.redhat.com/browse/KOGITO-7299[KOGITO-7299] - [KSW-Guides] Displaying workflow runtime data in serverless dashboards

--- a/serverlessworkflow/modules/ROOT/pages/release_notes.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/release_notes.adoc
@@ -1,21 +1,21 @@
-= What's new on {page-component-display-version}
+= New features on {page-component-display-version}
 :compat-mode!:
 
-== Notable Changes
+== Notable changes
 
-. link:https://issues.redhat.com/browse/KOGITO-7620[KOGITO-7620] - Improve events consumption thread pools configs
-. link:https://issues.redhat.com/browse/KOGITO-7612[KOGITO-7612] - Implement gRPC streaming scenarios
-. link:https://issues.redhat.com/browse/KOGITO-7538[KOGITO-7538] - gRPC enum behaviour
+* link:https://issues.redhat.com/browse/KOGITO-7620[KOGITO-7620] - Improve events consumption thread pools configs
+* link:https://issues.redhat.com/browse/KOGITO-7612[KOGITO-7612] - Implement gRPC streaming scenarios
+* link:https://issues.redhat.com/browse/KOGITO-7538[KOGITO-7538] - gRPC enum behaviour
 
-== Other Changes and Bug Fixing
+== Other changes and Bug fixes
 
-. link:https://issues.redhat.com/browse/KOGITO-7761[KOGITO-7761] - Kogito SW Guides latest version are pointing to main branch
-. link:https://issues.redhat.com/browse/KOGITO-7708[KOGITO-7708] - A few missing references and attributes are missing from the guides
-. link:https://issues.redhat.com/browse/KOGITO-7694[KOGITO-7694] - [KSW Guides] KN CLI generates project with different name and extensions than other options
-. link:https://issues.redhat.com/browse/KOGITO-7687[KOGITO-7687] - [KSW-Guides] - Restructure the guides to fit downstream structure
-. link:https://issues.redhat.com/browse/KOGITO-7636[KOGITO-7636] - [KSW-Guides] SW configuration properties guide
-. link:https://issues.redhat.com/browse/KOGITO-7611[KOGITO-7611] - Remove test-utils from the SW examples and replace by Dev Services
-. link:https://issues.redhat.com/browse/KOGITO-7610[KOGITO-7610] - [KSW-Guides] - Add How-To use RHBQ and Kogito productized artifacts
-. link:https://issues.redhat.com/browse/KOGITO-7309[KOGITO-7309] - [KSW-Guides] Integration tests with PostgreSQL
-. link:https://issues.redhat.com/browse/KOGITO-7301[KOGITO-7301] - [KSW-Guides] Persistence with PostgresSQL databases
-. link:https://issues.redhat.com/browse/KOGITO-7299[KOGITO-7299] - [KSW-Guides] Displaying workflow runtime data in serverless dashboards
+* link:https://issues.redhat.com/browse/KOGITO-7761[KOGITO-7761] - Kogito SW guides latest version is pointing to the main branch
+* link:https://issues.redhat.com/browse/KOGITO-7708[KOGITO-7708] - A few missing references and attributes are missing from the guides
+* link:https://issues.redhat.com/browse/KOGITO-7694[KOGITO-7694] - [KSW Guides] KN CLI generates a project with a different name and extensions than other options
+* link:https://issues.redhat.com/browse/KOGITO-7687[KOGITO-7687] - [KSW-Guides] - Restructure the guides to fit downstream structure
+* link:https://issues.redhat.com/browse/KOGITO-7636[KOGITO-7636] - [KSW-Guides] SW configuration properties guide
+* link:https://issues.redhat.com/browse/KOGITO-7611[KOGITO-7611] - Remove test-utils from the SW examples and replace by Dev Services
+* link:https://issues.redhat.com/browse/KOGITO-7610[KOGITO-7610] - [KSW-Guides] - Add How-To use RHBQ and Kogito productized artifacts
+* link:https://issues.redhat.com/browse/KOGITO-7309[KOGITO-7309] - [KSW-Guides] Integration tests with PostgreSQL
+* link:https://issues.redhat.com/browse/KOGITO-7301[KOGITO-7301] - [KSW-Guides] Persistence with PostgresSQL databases
+* link:https://issues.redhat.com/browse/KOGITO-7299[KOGITO-7299] - [KSW-Guides] Displaying workflow runtime data in serverless dashboards


### PR DESCRIPTION
Signed-off-by: Ricardo Zanini <zanini@redhat.com>

<!-- Please don't forget your JIRA link -->
**JIRA:**

<!-- If you don't have a JIRA link, please provide a short description of what this PR does -->
**Description:**

<!-- Link to related PRs: -->

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributions doc](https://github.com/kiegroup/kogito-docs/blob/main/CONTRIBUTING.md)
- [ ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [ ] The nav.adoc file has a link to this guide in the proper category
- [ ] The index.adoc file has a card to this guide in the proper category, with a meaningful description

<details>
<summary>
How to setup automatic cherry-pick to another branch ?
</summary>

The cherry-pick action allows to setup automatic cherry-pick from `main` to a specific branch.

To allow it, you will need to add the corresponding label with pattern: `backport-{RELEASE_BRANCH}`.  
For example, if a backport to branch `1.26.x` is needed, then the label should be `backport-1.26.x`.

Once the PR is merged, the action will retrieve the commit and cherry-pick it to the desired branch.

*NOTE: You can still add label after the merge and it should still be cherry-picked.*
</details>