### PR TITLE
KOGITO-7855 Fix colision of `:quarkus_config_url:`

### DIFF
--- a/serverlessworkflow/modules/ROOT/pages/service-orchestration/orchestration-of-openapi-based-services.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/service-orchestration/orchestration-of-openapi-based-services.adoc
@@ -11,7 +11,7 @@
 :dotnet_swagger_url: https://docs.microsoft.com/en-us/aspnet/core/tutorials/web-api-help-pages-using-swagger?view=aspnetcore-6.0
 :npm_swagger_url: https://www.npmjs.com/package/swagger-ui-express
 :php_swagger_url: https://github.com/zircote/swagger-php
-:quarkus_config_url: https://quarkus.io/guides/config-reference
+:quarkus_config_reference_url: https://quarkus.io/guides/config-reference
 :quarkus_rest_client_url: https://quarkus.io/guides/rest-client
 :mp_config_env_vars_url: https://github.com/eclipse/microprofile-config/blob/master/spec/src/main/asciidoc/configsources.asciidoc#environment-variables-mapping-rules
 // Referenced documentation pages.
@@ -375,7 +375,7 @@ quarkus.rest-client.subtraction_yaml.url=http://myserver.com
 ----
 --
 
-. To avoid hardcoding the URL in the `application.properties` file, you can use link:{quarkus_config_url}#with-environment-variables[environment variables substitution], as shown in the following example:
+. To avoid hardcoding the URL in the `application.properties` file, you can use link:{quarkus_config_reference_url}#with-environment-variables[environment variables substitution], as shown in the following example:
 +
 --
 .Example of URL configuration with environment variables


### PR DESCRIPTION
<!-- Please don't forget your JIRA link -->
**JIRA:** https://issues.redhat.com/projects/KOGITO/issues/KOGITO-7855

<!-- If you don't have a JIRA link, please provide a short description of what this PR does -->
<!-- Link to related PRs: -->

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributions doc](https://github.com/kiegroup/kogito-docs/blob/main/CONTRIBUTING.md)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [x] The nav.adoc file has a link to this guide in the proper category
- [x] The index.adoc file has a card to this guide in the proper category, with a meaningful description

<details>
<summary>
How to setup automatic cherry-pick to another branch ?
</summary>

The cherry-pick action allows to setup automatic cherry-pick from `main` to a specific branch.

To allow it, you will need to add the corresponding label with pattern: `backport-{RELEASE_BRANCH}`.  
For example, if a backport to branch `1.26.x` is needed, then the label should be `backport-1.26.x`.

Once the PR is merged, the action will retrieve the commit and cherry-pick it to the desired branch.

*NOTE: You can still add label after the merge and it should still be cherry-picked.*
</details>