### PR TITLE
KOGITO-7944 Fix `:knative_eventing_doc_url:` extra '/' and broken link

### DIFF
--- a/serverlessworkflow/modules/ROOT/pages/eventing/consume-produce-events-with-knative-eventing.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/eventing/consume-produce-events-with-knative-eventing.adoc
@@ -4,7 +4,7 @@
 :description: Consuming and producing events on Knative Eventing
 :keywords: kogito, workflow, serverless, events, knative, cloudevents
 // links
-:knative_eventing_doc_url: https://knative.dev/docs/eventing/
+:knative_eventing_doc_url: https://knative.dev/docs/eventing
 :knative_serving_services_url: https://knative.dev/docs/serving/services/
 :kubernetes_probes_url: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
 :quarkus_k8s_url: https://quarkus.io/guides/deploying-to-kubernetes
@@ -142,7 +142,7 @@ The following table lists the configuration properties related to Knative sink g
 
 The configuration described in this section is useful if your workflow consists of at least one `consumed` type link:{spec_doc_url}#Event-Definition[event definition]. In this scenario, the workflow application consumes events, acting as a Knative sink.
 
-When the workflow application needs to consume events, the Knative Eventing add-on generates link:{knative_eventing_doc_url}/broker/triggers[Knative triggers]. The Knative triggers are configured to listen to a broker with the required event type, which is defined in your workflow definition.
+When the workflow application needs to consume events, the Knative Eventing add-on generates link:{knative_eventing_doc_url}/triggers[Knative triggers]. The Knative triggers are configured to listen to a broker with the required event type, which is defined in your workflow definition.
 
 The following table lists the configuration property related to Knative sink generation:
 


### PR DESCRIPTION
<!-- Please don't forget your JIRA link -->
**JIRA:**
https://issues.redhat.com/browse/KOGITO-7944
<!-- If you don't have a JIRA link, please provide a short description of what this PR does -->

<!-- Link to related PRs: -->

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributions doc](https://github.com/kiegroup/kogito-docs/blob/main/CONTRIBUTING.md)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [x] The nav.adoc file has a link to this guide in the proper category
- [x] The index.adoc file has a card to this guide in the proper category, with a meaningful description

<details>
<summary>
How to setup automatic cherry-pick to another branch ?
</summary>

The cherry-pick action allows to setup automatic cherry-pick from `main` to a specific branch.

To allow it, you will need to add the corresponding label with pattern: `backport-{RELEASE_BRANCH}`.  
For example, if a backport to branch `1.26.x` is needed, then the label should be `backport-1.26.x`.

Once the PR is merged, the action will retrieve the commit and cherry-pick it to the desired branch.

*NOTE: You can still add label after the merge and it should still be cherry-picked.*
</details>