### PR TITLE
Templating release notes for snapshot versions

### DIFF
--- a/serverlessworkflow/modules/ROOT/pages/release_notes.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/release_notes.adoc
@@ -3,19 +3,9 @@
 
 == Notable changes
 
-* link:https://issues.redhat.com/browse/KOGITO-7620[KOGITO-7620] - Improve events consumption thread pools configs
-* link:https://issues.redhat.com/browse/KOGITO-7612[KOGITO-7612] - Implement gRPC streaming scenarios
-* link:https://issues.redhat.com/browse/KOGITO-7538[KOGITO-7538] - gRPC enum behaviour
+// * link:https://issues.redhat.com/browse/KOGITO-XXXX[KOGITO-XXXX] - <description>
+
 
 == Other changes and Bug fixes
 
-* link:https://issues.redhat.com/browse/KOGITO-7761[KOGITO-7761] - Kogito SW guides latest version is pointing to the main branch
-* link:https://issues.redhat.com/browse/KOGITO-7708[KOGITO-7708] - A few missing references and attributes are missing from the guides
-* link:https://issues.redhat.com/browse/KOGITO-7694[KOGITO-7694] - [KSW Guides] KN CLI generates a project with a different name and extensions than other options
-* link:https://issues.redhat.com/browse/KOGITO-7687[KOGITO-7687] - [KSW-Guides] - Restructure the guides to fit downstream structure
-* link:https://issues.redhat.com/browse/KOGITO-7636[KOGITO-7636] - [KSW-Guides] SW configuration properties guide
-* link:https://issues.redhat.com/browse/KOGITO-7611[KOGITO-7611] - Remove test-utils from the SW examples and replace by Dev Services
-* link:https://issues.redhat.com/browse/KOGITO-7610[KOGITO-7610] - [KSW-Guides] - Add How-To use RHBQ and Kogito productized artifacts
-* link:https://issues.redhat.com/browse/KOGITO-7309[KOGITO-7309] - [KSW-Guides] Integration tests with PostgreSQL
-* link:https://issues.redhat.com/browse/KOGITO-7301[KOGITO-7301] - [KSW-Guides] Persistence with PostgresSQL databases
-* link:https://issues.redhat.com/browse/KOGITO-7299[KOGITO-7299] - [KSW-Guides] Displaying workflow runtime data in serverless dashboards
+// * link:https://issues.redhat.com/browse/KOGITO-XXXX[KOGITO-XXXX] - <description>


### PR DESCRIPTION
Let the Release Notes in main be a template rather than an old version.