### PR TITLE
Adding kaldesai as codeowner for docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 *	@ricardozanini @krisv
 
-*.adoc	@hmanwani-rh @radtriste @MarianMacik
-*.md	@hmanwani-rh
+*.adoc	@kaldesai @radtriste @MarianMacik
+*.md	@kaldesai
 Jenkinsfile* @radtriste


### PR DESCRIPTION
Since @kaldesai will now help us while @hmanwani-rh is on PTO, I'm changing the approval chain to her.