### PR TITLE
[1.28.x] KOGITO-8043 Jenkins node master -> built-in

### DIFF
--- a/.ci/jenkins/Jenkinsfile.init-branch
+++ b/.ci/jenkins/Jenkinsfile.init-branch
@@ -4,7 +4,7 @@ import org.jenkinsci.plugins.workflow.libs.Library
 
 pipeline {
     agent {
-        label 'kie-rhel7 && !master'
+        label 'kie-rhel7 && !built-in'
     }
 
     tools {

--- a/.ci/jenkins/Jenkinsfile.post-release
+++ b/.ci/jenkins/Jenkinsfile.post-release
@@ -4,7 +4,7 @@ import org.jenkinsci.plugins.workflow.libs.Library
 
 pipeline {
     agent {
-        label 'kie-rhel7 && !master'
+        label 'kie-rhel7 && !built-in'
     }
 
     tools {


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-8043

Related:
- https://github.com/kiegroup/kogito-pipelines/pull/634
- https://github.com/kiegroup/kogito-pipelines/pull/636
- https://github.com/kiegroup/drools/pull/4725
- https://github.com/kiegroup/kogito-runtimes/pull/2527
- https://github.com/kiegroup/kogito-apps/pull/1485
- https://github.com/kiegroup/kogito-examples/pull/1425
- https://github.com/kiegroup/kogito-images/pull/1344
- https://github.com/kiegroup/kogito-operator/pull/1295
- https://github.com/kiegroup/kogito-docs/pull/220