### PR TITLE
Docs Patch PR for KOGITO-7967: Improve clarity of procedure to start gRPC application in the guide

### DIFF
--- a/serverlessworkflow/modules/ROOT/pages/service-orchestration/orchestration-of-grpc-services.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/service-orchestration/orchestration-of-grpc-services.adoc
@@ -149,7 +149,7 @@ In the same GitHub repository as the example application, there is a link:{grpc_
 == Default enum values
 
 gRPC link:{grpc_enum_url}[specification] requires enumeration types to have a default value. The default value is not included in the server response payload. Therefore, use an empty value such as `UNKNOWN` as default.
-If, for any reason, your default value is semantically valid and you want the value to be included in the workflow model, you must set `kogito.grpc.enum.includeDefault` property to true. This way enumeration fields are always filled by the workflow if the server response does not include them. 
+If, for any reason, your default value is semantically valid and you want the value to be included in the workflow model, you must set `kogito.grpc.enum.includeDefault` property to true. This way enumeration fields are always filled by the workflow if the server response does not include them.
 
 [[running-serverless-workflow-application]]
 == Running the workflow application
@@ -161,7 +161,7 @@ If, for any reason, your default value is semantically valid and you want the va
 mvn compile exec:java -Dexec.mainClass="org.kie.kogito.examples.sw.greeting.GreeterService"
 ----
 
-. Once the server is running, you need to navigate to the `serverless-workflow-greeting-client-rpc-quarkus` directory in a separate command terminal and run the workflow application by entering the command: 
+. Once the server is running, you must navigate to the `serverless-workflow-greeting-client-rpc-quarkus` directory in a separate command terminal and run the workflow application by entering the following command: 
 +
 [source,shell]
 ----


### PR DESCRIPTION

<!-- Please don't forget your JIRA link -->
**JIRA:** [KOGITO-7967](https://issues.redhat.com/browse/KOGITO-7967)

<!-- If you don't have a JIRA link, please provide a short description of what this PR does -->
**Description:** I reviewed the content for the procedure to start the gRPC application in the guide. 

<!-- Link to related PRs: -->

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributions doc](https://github.com/kiegroup/kogito-docs/blob/main/CONTRIBUTING.md)
- [ ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [ ] The nav.adoc file has a link to this guide in the proper category
- [ ] The index.adoc file has a card to this guide in the proper category, with a meaningful description

<details>
<summary>
How to set up automatic cherry-pick to another branch?
</summary>

The cherry-pick action allows to setup automatic cherry-pick from `main` to a specific branch.

To allow it, you will need to add the corresponding label with pattern: `backport-{RELEASE_BRANCH}`.  
For example, if a backport to branch `1.26.x` is needed, then the label should be `backport-1.26.x`.

Once the PR is merged, the action will retrieve the commit and cherry-pick it to the desired branch.

*NOTE: You can still add label after the merge and it should still be cherry-picked.*
</details>