### PR TITLE
Updating icon for timeout support in CNCF section

### DIFF
--- a/serverlessworkflow/modules/ROOT/pages/getting-started/cncf-serverless-workflow-specification-support.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/getting-started/cncf-serverless-workflow-specification-support.adoc
@@ -67,7 +67,7 @@ specification.
 | link:{spec_doc_url}#Retry-Definition[Retry Definition]
 
 | <<timeouts>>
-| emoji:construction[]
+| emoji:last_quarter_moon[]
 | link:{spec_doc_url}#workflow-timeouts[Workflow Timeouts]
 
 | <<compensation>>

--- a/serverlessworkflow/modules/ROOT/pages/getting-started/cncf-serverless-workflow-specification-support.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/getting-started/cncf-serverless-workflow-specification-support.adoc
@@ -234,6 +234,8 @@ Alternatively, you can use xref:core/understanding-workflow-error-handling.adoc[
 {product_name} has limited support for the Timeouts feature, which covers only *Callback* and *Switch* states with events.
 Other states will be included in future releases.
 
+For more information about timeouts, see xref:core/timeouts-support.adoc[Timeouts on events for {context}].
+
 [[compensation]]
 == Compensation
 


### PR DESCRIPTION
<!-- If you don't have a JIRA link, please provide a short description of what this PR does -->
**Description:** 
Updating the CNCF section with the icon for partial implementation of timeouts, the text was already updated in the guide PR.

<!-- Link to related PRs: -->

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributions doc](https://github.com/kiegroup/kogito-docs/blob/main/CONTRIBUTING.md)
- [ ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [ ] The nav.adoc file has a link to this guide in the proper category
- [ ] The index.adoc file has a card to this guide in the proper category, with a meaningful description

<details>
<summary>
How to setup automatic cherry-pick to another branch ?
</summary>

The cherry-pick action allows to setup automatic cherry-pick from `main` to a specific branch.

To allow it, you will need to add the corresponding label with pattern: `backport-{RELEASE_BRANCH}`.  
For example, if a backport to branch `1.26.x` is needed, then the label should be `backport-1.26.x`.

Once the PR is merged, the action will retrieve the commit and cherry-pick it to the desired branch.

*NOTE: You can still add label after the merge and it should still be cherry-picked.*
</details>