### PR TITLE
KOGITO-7975 Removed workflowdata property from requests

### DIFF
--- a/serverlessworkflow/modules/ROOT/pages/cloud/build-workflow-image-with-quarkus-cli.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/build-workflow-image-with-quarkus-cli.adoc
@@ -242,7 +242,7 @@ Example request::
 +
 [source,shell]
 ----
-curl -X POST -H 'Content-Type:application/json' -H 'Accept:application/json' -d '{"workflowdata" : {"name": "John", "language": "English"}}' http://localhost:8080/jsongreet
+curl -X POST -H 'Content-Type:application/json' -H 'Accept:application/json' -d '{""name": "John", "language": "English"}' http://localhost:8080/jsongreet
 ----
 Example response::
 +

--- a/serverlessworkflow/modules/ROOT/pages/cloud/build-workflow-image-with-quarkus-cli.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/build-workflow-image-with-quarkus-cli.adoc
@@ -242,7 +242,7 @@ Example request::
 +
 [source,shell]
 ----
-curl -X POST -H 'Content-Type:application/json' -H 'Accept:application/json' -d '{""name": "John", "language": "English"}' http://localhost:8080/jsongreet
+curl -X POST -H 'Content-Type:application/json' -H 'Accept:application/json' -d '{"name": "John", "language": "English"}' http://localhost:8080/jsongreet
 ----
 Example response::
 +

--- a/serverlessworkflow/modules/ROOT/pages/cloud/deploying-on-minikube.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/deploying-on-minikube.adoc
@@ -555,7 +555,7 @@ greeting-quarkus-cli   http://greeting-quarkus-cli.serverless-workflow-greeting-
 .Access your workflow application
 [source,shell]
 ----
-curl -X POST -H 'Content-Type:application/json' -H 'Accept:application/json' -d '{"workflowdata" : {"name": "John", "language": "English"}}' http://greeting-quarkus-cli.serverless-workflow-greeting-quarkus.10.103.94.37.sslip.io/jsongreet.37.sslip.io/jsongreet
+curl -X POST -H 'Content-Type:application/json' -H 'Accept:application/json' -d '{"name": "John", "language": "English"}' http://greeting-quarkus-cli.serverless-workflow-greeting-quarkus.10.103.94.37.sslip.io/jsongreet.37.sslip.io/jsongreet
 ----
 --
 

--- a/serverlessworkflow/modules/ROOT/pages/cloud/deploying-on-minikube.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/deploying-on-minikube.adoc
@@ -294,7 +294,7 @@ http://hello.serverless-workflow-greeting-quarkus.10.103.94.37.sslip.io
 .Example request
 [source,shell]
 ----
-curl -X POST -H 'Content-Type:application/json' -H 'Accept:application/json' -d '{"workflowdata" : {"name": "John", "language": "English"}}' http://hello.serverless-workflow-greeting-quarkus.10.103.94.37.sslip.io/jsongreet
+curl -X POST -H 'Content-Type:application/json' -H 'Accept:application/json' -d '{"name": "John", "language": "English"}' http://hello.serverless-workflow-greeting-quarkus.10.103.94.37.sslip.io/jsongreet
 ----
 
 .Example response
@@ -473,7 +473,7 @@ greeting-quarkus-kubectl   http://greeting-quarkus-kubectl.serverless-workflow-g
 .Access workflow application
 [source,shell]
 ----
-curl -X POST -H 'Content-Type:application/json' -H 'Accept:application/json' -d '{"workflowdata" : {"name": "John", "language": "English"}}' http://greeting-quarkus-kubectl.serverless-workflow-greeting-quarkus.10.103.94.37.sslip.io/jsongreet
+curl -X POST -H 'Content-Type:application/json' -H 'Accept:application/json' -d '{"name": "John", "language": "English"}' http://greeting-quarkus-kubectl.serverless-workflow-greeting-quarkus.10.103.94.37.sslip.io/jsongreet
 ----
 --
 

--- a/serverlessworkflow/modules/ROOT/pages/core/timeouts-support.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/core/timeouts-support.adoc
@@ -354,9 +354,7 @@ curl -X 'POST' \
 'http://timeouts-showcase.default.10.105.86.217.sslip.io/callback_state_timeouts' \
 -H 'accept: */*' \
 -H 'Content-Type: application/json' \
--d '{
-"workflowdata": {}
-}'
+-d '{}'
 ----
 
 * Switch
@@ -368,9 +366,7 @@ curl -X 'POST' \
 'http://timeouts-showcase.default.10.105.86.217.sslip.io/callback_state_timeouts' \
 -H 'accept: */*' \
 -H 'Content-Type: application/json' \
--d '{
-"workflowdata": {}
-}'
+-d '{}'
 ----
 
 * Checking whether the workflow instance was created

--- a/serverlessworkflow/modules/ROOT/pages/core/understanding-jq-expressions.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/core/understanding-jq-expressions.adoc
@@ -8,7 +8,7 @@
 :jsonpath_url: https://github.com/json-path/JsonPath/
 :json_data_types_url: https://www.w3schools.com/js/js_json_datatypes.asp
 
-Each workflow instance is associated with a data model. A data model consists of a JSON object regardless of whether the workflow file contains YAML or JSON. The initial content of the JSON object depends on how the workflow is started. If the workflow is created using link:{cloud_events_url}[Cloud Event], then the workflow content is taken from the `data` property. However, if the workflow is started through an HTTP POST invocation, then the workflow content is taken from the `workflowdata` property.
+Each workflow instance is associated with a data model. A data model consists of a JSON object regardless of whether the workflow file contains YAML or JSON. The initial content of the JSON object depends on how the workflow is started. If the workflow is created using link:{cloud_events_url}[Cloud Event], then the workflow content is taken from the `data` property. However, if the workflow is started through an HTTP POST invocation, then the workflow content is taken from the request body.
 
 The workflow expressions in the link:{spec_doc_url}#workflow-expressions[Serverless Workflow specification] are used to interact with the data model. The supported expression languages include link:{jsonpath_url}[JsonPath] and link:{jq_url}[jq]. jq expression language is the default language. However, you can change the expression language to JsonPath using the `expressionLang` property. 
 

--- a/serverlessworkflow/modules/ROOT/pages/core/understanding-jq-expressions.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/core/understanding-jq-expressions.adoc
@@ -8,7 +8,7 @@
 :jsonpath_url: https://github.com/json-path/JsonPath/
 :json_data_types_url: https://www.w3schools.com/js/js_json_datatypes.asp
 
-Each workflow instance is associated with a data model. A data model consists of a JSON object regardless of whether the workflow file contains YAML or JSON. The initial content of the JSON object depends on how the workflow is started. If the workflow is created using link:{cloud_events_url}[Cloud Event], then the workflow content is taken from the `data` property. However, if the workflow is started through an HTTP POST invocation, then the workflow content is taken from the request body.
+Each workflow instance is associated with a data model. A data model consists of a JSON object regardless of whether the workflow file contains YAML or JSON. The initial content of the JSON object depends on how the workflow is started. If the workflow is created using the link:{cloud_events_url}[Cloud Event], then the workflow content is taken from the `data` property. However, if the workflow is started through an HTTP POST request, then the workflow content is taken from the request body.
 
 The workflow expressions in the link:{spec_doc_url}#workflow-expressions[Serverless Workflow specification] are used to interact with the data model. The supported expression languages include link:{jsonpath_url}[JsonPath] and link:{jq_url}[jq]. jq expression language is the default language. However, you can change the expression language to JsonPath using the `expressionLang` property. 
 

--- a/serverlessworkflow/modules/ROOT/pages/core/working-with-parallelism.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/core/working-with-parallelism.adoc
@@ -251,9 +251,7 @@ curl -X 'POST' \
   'http://localhost:8080/parallel' \
   -H 'accept: */*' \
   -H 'Content-Type: application/json' \
-  -d '{
-  "workflowdata": {}
-}'
+  -d '{}'
 ----
 
 .Example response

--- a/serverlessworkflow/modules/ROOT/pages/core/working-with-parallelism.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/core/working-with-parallelism.adoc
@@ -139,9 +139,7 @@ curl -X 'POST' \
   'http://localhost:8080/parallel' \
   -H 'accept: */*' \
   -H 'Content-Type: application/json' \
-  -d '{
-  "workflowdata": {}
-}'
+  -d '{}'
 ----
 
 .Example response

--- a/serverlessworkflow/modules/ROOT/pages/security/orchestrating-third-party-services-with-oauth2.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/security/orchestrating-third-party-services-with-oauth2.adoc
@@ -547,12 +547,10 @@ curl -X 'POST' \
   -H 'accept: */*' \
   -H 'Content-Type: application/json' \
   -d '{
-        "workflowdata": {
-           "currencyFrom": "EUR",
-           "currencyTo": "USD",
-           "exchangeDate": "2022-06-10",
-           "amount": 2.0
-       }
+       "currencyFrom": "EUR",
+       "currencyTo": "USD",
+       "exchangeDate": "2022-06-10",
+       "amount": 2.0
     }'
 ----
 Example response::
@@ -588,12 +586,10 @@ curl -X 'POST' \
   -H 'accept: */*' \
   -H 'Content-Type: application/json' \
   -d '{
-  "workflowdata": {
     "currencyFrom": "EUR",
     "currencyTo": "MXN",
     "exchangeDate": "2022-06-10",
     "amount": 2.0
-  }
 }'
 ----
 Example response::
@@ -635,12 +631,10 @@ curl -X 'POST' \
   -H 'accept: */*' \
   -H 'Content-Type: application/json' \
   -d '{
-  "workflowdata": {
     "currencyFrom": "EUR",
     "currencyTo": "USD",
     "exchangeDate": "2022-06-10",
     "amount": 2.0
-  }
 }'
 ----
 Example response::

--- a/serverlessworkflow/modules/ROOT/pages/service-orchestration/configuring-openapi-services-endpoints.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/service-orchestration/configuring-openapi-services-endpoints.adoc
@@ -364,7 +364,7 @@ curl -X 'POST' \
   'http://localhost:8080/stockprofit' \
   -H 'accept: */*' \
   -H 'Content-Type: application/json' \
-  -d '{ "workflowdata": {"symbol": "KGTO" } }'
+  -d '{ "symbol": "KGTO" }'
 ----
 
 .Example response
@@ -418,7 +418,7 @@ curl -X 'POST' \
   'http://localhost:8080/stockprofit' \
   -H 'accept: */*' \
   -H 'Content-Type: application/json' \
-  -d '{ "workflowdata": {"symbol": "KGTO" } }'
+  -d '{ "symbol": "KGTO" }'
 ----
 
 .Example response
@@ -465,7 +465,7 @@ curl -X 'POST' \
   'http://localhost:8080/stockprofit' \
   -H 'accept: */*' \
   -H 'Content-Type: application/json' \
-  -d '{ "workflowdata": {"symbol": "KGTO" } }'
+  -d '{ "symbol": "KGTO" }'
 ----
 
 .Example response

--- a/serverlessworkflow/modules/ROOT/pages/service-orchestration/orchestration-of-grpc-services.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/service-orchestration/orchestration-of-grpc-services.adoc
@@ -175,7 +175,7 @@ mvn clean quarkus:dev
 .Example request
 [source,shell]
 ----
-curl -X POST -H 'Content-Type:application/json' -H 'Accept:application/json' -d '{"workflowdata" : {"name": "John", "language": "English"}}' http://localhost:8080/jsongreet
+curl -X POST -H 'Content-Type:application/json' -H 'Accept:application/json' -d '{"name": "John", "language": "English"}' http://localhost:8080/jsongreet
 ----
 
 .Example response
@@ -188,7 +188,7 @@ You can also try greeting in a different language.
 
 [source,shell]
 ----
-curl -X POST -H 'Content-Type:application/json' -H 'Accept:application/json' -d '{"workflowdata" : {"name": "Javi", "language": "Spanish"}}' http://localhost:8080/jsongreet
+curl -X POST -H 'Content-Type:application/json' -H 'Accept:application/json' -d '{"name": "Javi", "language": "Spanish"}' http://localhost:8080/jsongreet
 ----
 
 In response, you will see the greeting in Spanish language.
@@ -198,7 +198,7 @@ In response, you will see the greeting in Spanish language.
 .Example request
 [source,shell]
 ----
-curl -X POST -H 'Content-Type:application/json' -H 'Accept:application/json' -d '{"workflowdata" : {"name": "John"}}' http://localhost:8080/jsongreetserverstream
+curl -X POST -H 'Content-Type:application/json' -H 'Accept:application/json' -d '{"name": "John"}' http://localhost:8080/jsongreetserverstream
 ----
 
 .Example response
@@ -212,12 +212,7 @@ curl -X POST -H 'Content-Type:application/json' -H 'Accept:application/json' -d 
 .Example request
 [source,shell]
 ----
-curl -X POST -H 'Content-Type:application/json' -H 'Accept:application/json' -d '{"workflowdata" : {
-                                                                                                    "helloRequests" : [
-                                                                                                                        {"name" : "Javierito", "language":"Spanish"},
-                                                                                                                        {"name" : "John", "language":"English"},
-                                                                                                                        {"name" : "Jan", "language":"Czech"}
-                                                                                                                      ]}}' http://localhost:8080/jsongreetclientstream
+curl -X POST -H 'Content-Type:application/json' -H 'Accept:application/json' -d '{"helloRequests" : [{"name" : "Javierito", "language":"Spanish"}, {"name" : "John", "language":"English"}, {"name" : "Jan", "language":"Czech"}]}' http://localhost:8080/jsongreetclientstream
 ----
 
 .Example response
@@ -241,12 +236,7 @@ curl -X POST -H 'Content-Type:application/json' -H 'Accept:application/json' -d 
 .Example request
 [source,shell]
 ----
-curl -X POST -H 'Content-Type:application/json' -H 'Accept:application/json' -d '{"workflowdata" : {
-                                                                                                    "helloRequests" : [
-                                                                                                                        {"name" : "Javierito", "language":"Spanish"},
-                                                                                                                        {"name" : "John", "language":"English"},
-                                                                                                                        {"name" : "Jan", "language":"Czech"}
-                                                                                                                      ]}}' http://localhost:8080/jsongreetbidistream
+curl -X POST -H 'Content-Type:application/json' -H 'Accept:application/json' -d '{"helloRequests" : [{"name" : "Javierito", "language":"Spanish"},{"name" : "John", "language":"English"},{"name" : "Jan", "language":"Czech"}]}' http://localhost:8080/jsongreetbidistream
 ----
 
 .Example response

--- a/serverlessworkflow/modules/ROOT/pages/testing-and-troubleshooting/basic-integration-tests-with-restassured.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/testing-and-troubleshooting/basic-integration-tests-with-restassured.adoc
@@ -16,9 +16,7 @@ The following procedure describes how to test a workflow application that expose
 [source,json]
 ----
 {
-  "workflowdata": {
-    "name": "John Doe"
-  }
+  "name": "John Doe"
 }
 ----
 
@@ -87,7 +85,7 @@ class HelloTest {
         given()
                 .contentType(ContentType.JSON) <2>
                 .accept(ContentType.JSON) <3>
-                .body("{\"workflowdata\": {\"name\": \"John Doe\"}}") <4>
+                .body("{\"name\": \"John Doe\"}") <4>
                 .when()
                 .post("/hello") <5>
                 .then()
@@ -100,7 +98,7 @@ class HelloTest {
 <1> Enables logging of the request and response when the test fails.
 <2> Defines JSON as the content type of the request.
 <3> Specifies the `accept` header of the request. This is an alternative for `header("Accept", "application/json")`.
-<4> Defines the request body as `{"workflowdata": {"name": "John Doe"}}`.
+<4> Defines the request body as `{"name": "John Doe"}`.
 <5> Specifies the request as a POST method to the `/hello` URL.
 <6> Defines `201` as the expected response status code.
 <7> Defines that `Hello, John Doe` is expected in the `workflowdata.greeting` JSON path.

--- a/serverlessworkflow/modules/ROOT/pages/use-cases/orchestration-based-saga-pattern.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/use-cases/orchestration-based-saga-pattern.adoc
@@ -172,9 +172,7 @@ You can use the following example to send a request for creating an order:
 [source,shell]
 ----
 curl -L -X POST "http://localhost:8080/order_saga_error_workflow" -H 'Content-Type: application/json' --data-raw '{
- "workflowdata": {
   "orderId": "03e6cf79-3301-434b-b5e1-d6899b5639aa"
- }
 }'
 ----
 
@@ -230,10 +228,8 @@ To test the workflow, an optional `failService` attribute is introduced, indicat
 [source,shell]
 ----
 curl -L -X POST 'http://localhost:8080/order_saga_error_workflow' -H 'Content-Type: application/json' --data-raw '{
- "workflowdata": {
   "orderId": "03e6cf79-3301-434b-b5e1-d6899b5639aa",
   "failService": "ShippingService"
- }
 }'
 ----
 


### PR DESCRIPTION
**JIRA:** https://issues.redhat.com/browse/KOGITO-7975

Related PR: https://github.com/kiegroup/kogito-examples/pull/1446

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributions doc](https://github.com/kiegroup/kogito-docs/blob/main/CONTRIBUTING.md)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [x] The nav.adoc file has a link to this guide in the proper category
- [x] The index.adoc file has a card to this guide in the proper category, with a meaningful description

<details>
<summary>
How to setup automatic cherry-pick to another branch ?
</summary>

The cherry-pick action allows to setup automatic cherry-pick from `main` to a specific branch.

To allow it, you will need to add the corresponding label with pattern: `backport-{RELEASE_BRANCH}`.  
For example, if a backport to branch `1.26.x` is needed, then the label should be `backport-1.26.x`.

Once the PR is merged, the action will retrieve the commit and cherry-pick it to the desired branch.

*NOTE: You can still add label after the merge and it should still be cherry-picked.*
</details>