### PR TITLE
Docs Patch PR for KOGITO-8078: Document adding custom type through addon

### DIFF
--- a/serverlessworkflow/modules/ROOT/pages/core/custom-functions-support.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/core/custom-functions-support.adoc
@@ -212,7 +212,7 @@ Kogito add-ons relies on the link:{quarkus_guides_base_url}/writing-extensions[Q
 - The deployment module, which is responsible for generating the code required for the extension to work.
 - The runtime module, which includes the non-generated classes that are required for the extension to work.
 
-In the case of a Serverless workflow custom type, following are the roles of the modules:
+In the case of a Serverless Workflow custom type, following are the roles of the modules:
 
 - *The deployment project*
 +
@@ -223,13 +223,13 @@ It must contain a Java class that inherits from `WorkItemTypeHandler`. Its respo
 +
 The runtime project consists of a `WorkflowWorkItemHandler` implementation, which name must match with the one provided to `WorkItemNodeFactory` during the deployment phase, and a `WorkItemHandlerConfig` bean that registers that handler with that name.
 +
-When a Serverless workflow function is called, Kogito identifies the proper `WorkflowWorkItemHandler` instance to be used for that function type (using the handler name associated with that type by the deployment project) and then invokes the `internalExecute` method. The `Map` parameter contains the function arguments defined in the workflow, and the `WorkItem` parameter contains the metadata information added to the handler by the deployment project. Hence, the `executeWorkItem` implementation has an access to all the information needed to perform the computational logic intended for that custom type.
+When a Serverless Workflow function is called, Kogito identifies the proper `WorkflowWorkItemHandler` instance to be used for that function type (using the handler name associated with that type by the deployment project) and then invokes the `internalExecute` method. The `Map` parameter contains the function arguments defined in the workflow, and the `WorkItem` parameter contains the metadata information added to the handler by the deployment project. Hence, the `executeWorkItem` implementation has an access to all the information needed to perform the computational logic intended for that custom type.
 
 === Custom function type example
 
 Assuming you want to interact, from a workflow file, with a legacy RPC server as the one defined in link:{kogito_sw_examples_url}/serverless-workflow-custom-type/serverless-workflow-custom-rpc-server[this project]. This legacy server supports four simple arithmetic operations: add, minus, multiply and divide, which can be invoked using a custom RPC protocol.
 
-Since this is an uncommon protocol, the workflow cannot handle them by using any of the predefined Serverless workflow function types. The available options are to use a Java service, which invokes a Java class that knows how to interact with the server, or define a custom type that knows how to interact with the service.
+Since this is an uncommon protocol, the workflow cannot handle them by using any of the predefined Serverless Workflow function types. The available options are to use a Java service, which invokes a Java class that knows how to interact with the server, or define a custom type that knows how to interact with the service.
 
 Using the recent approach, you can write a link:{kogito_sw_examples_url}/serverless-workflow-custom-type/serverless-workflow-custom-type-example/src/main/resources/customType.sw.json[workflow file] defining this function.
 
@@ -246,9 +246,9 @@ Using the recent approach, you can write a link:{kogito_sw_examples_url}/serverl
   ],
 ----
 
-The `operation` starts with `rpc`, which is the custom type identifier, and continues with `division`, which denotes the operation that is going to be executed in the legacy server.
+The `operation` starts with `rpc`, which is the custom type identifier, and continues with `division`, which denotes the operation that will be executed in the legacy server.
 
-For this function definition to be identified, a Kogito addon that defines the `rpc` custom type must be developed. It is consist of a link:{kogito_sw_examples_url}/serverless-workflow-custom-type/serverless-workflow-custom-rpc-deployment[deployment project] and a link:{kogito_sw_examples_url}/serverless-workflow-custom-type/serverless-workflow-custom-rpc[runtime project].
+A Kogito addon that defines the `rpc` custom type must be developed for this function definition to be identified. It is consist of a link:{kogito_sw_examples_url}/serverless-workflow-custom-type/serverless-workflow-custom-rpc-deployment[deployment project] and a link:{kogito_sw_examples_url}/serverless-workflow-custom-type/serverless-workflow-custom-rpc[runtime project].
 
 The deployment project is responsible for extending the link:{kogito_sw_examples_url}/serverless-workflow-custom-type/serverless-workflow-custom-rpc-deployment/src/main/java/org/kie/kogito/examples/sw/services/RPCCustomTypeHandler.java[`WorkItemTypeHandler`] and setup the `WorkItemNodeFactory` as follows:
 
@@ -259,6 +259,15 @@ The deployment project is responsible for extending the link:{kogito_sw_examples
 
 import static org.kie.kogito.examples.sw.custom.RPCCustomWorkItemHandler.NAME;
 import static org.kie.kogito.examples.sw.custom.RPCCustomWorkItemHandler.OPERATION;
+
+public class RPCCustomTypeHandler extends WorkItemTypeHandler{
+
+
+    @Override
+    public String type() {
+        return "rpc";
+    }
+
     @Override
     protected <T extends RuleFlowNodeContainerFactory<T, ?>> WorkItemNodeFactory<T> fillWorkItemHandler(Workflow workflow,
                                                                                                         ParserContext context,
@@ -266,9 +275,11 @@ import static org.kie.kogito.examples.sw.custom.RPCCustomWorkItemHandler.OPERATI
                                                                                                         FunctionDefinition functionDef) {
         return node.workName(NAME).metaData(OPERATION, trimCustomOperation(functionDef));
     }
+}
+
 ----
 
-This example setups the name of the `KogitoWorkItemHandler` and adds a metadata key that extracts the name of the operation to perform in the legacy server from the Serverless workflow function definition.
+This example setups the name of the `KogitoWorkItemHandler`, adds a metadata key with the name of the remote operation (extracted from the Serverless Workflow function definition operation property), and declares that the custom type is named as `rpc`.
 
 The Runtime project contains the link:{kogito_sw_examples_url}/serverless-workflow-custom-type/serverless-workflow-custom-rpc/src/main/java/org/kie/kogito/examples/sw/custom/RPCCustomWorkItemHandler.java[KogitoWorkItemHandler] and the link:{kogito_sw_examples_url}/serverless-workflow-custom-type/serverless-workflow-custom-rpc/src/main/java/org/kie/kogito/examples/sw/custom/RPCCustomWorkItemHandlerConfig.java[WorkItemHandlerConfig] implementations.
 

--- a/serverlessworkflow/modules/ROOT/pages/core/custom-functions-support.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/core/custom-functions-support.adoc
@@ -94,7 +94,7 @@ The following example shows the declaration of a `java` function:
 
 === Function Arguments
 
-Your method interface signature must copy the arguments passed by the workflow. 
+Your method interface signature must copy the arguments passed by the workflow.
 
 For example, if you invoke a function using one argument as follows, then your method signature assumes that the `number` model variable is an integer:
 
@@ -114,8 +114,8 @@ For example, if you invoke a function using one argument as follows, then your m
 .Example of a `java` function implementation
 [source,java]
 ----
-public class MyInterfaceOrClass { 
-  
+public class MyInterfaceOrClass {
+
   public void myMethod(int number) {
         if (number % 2 != 0) {
             throw new IllegalArgumentException("Odd situation");
@@ -126,7 +126,7 @@ public class MyInterfaceOrClass {
 
 As a particular case, if you provide no argument in the workflow definition, the signature of the Java method might include a link:https://github.com/FasterXML/jackson[Jackson's] `JsonNode` parameter. This means that the Java method expects the entire workflow model as input.
 
-When using the following example function reference with no arguments, and if the method signature contains a `JsonNode` parameter, the entire workflow model is passed when the method call is performed. 
+When using the following example function reference with no arguments, and if the method signature contains a `JsonNode` parameter, the entire workflow model is passed when the method call is performed.
 
 .Example of a `java` function reference with no arguments
 [source,json]
@@ -160,7 +160,7 @@ If your method returns a `JsonNode`, the content of that node is merged into the
 
 The same occurs if your method returns any Java `Object` descendant that is not a primitive wrapper, the Java object is recursively converted to a JSON object and the result is merged into the workflow model (you can use an action data filter to control what is merged).
 
-If your method returns a primitive type or their corresponding wrapper object (int, boolean, long, and so on), then the primitive value is added to the workflow model with the name `response` (you can change that name using an action data filter). 
+If your method returns a primitive type or their corresponding wrapper object (int, boolean, long, and so on), then the primitive value is added to the workflow model with the name `response` (you can change that name using an action data filter).
 
 If your method returns Java collections, it is converted to a JSON array and added to the workflow model with the name `response` (you can change that name using an action data filter).
 
@@ -174,16 +174,14 @@ Therefore, if you need to do so, you can update the signature of methods from pr
 [source,java]
 ----
 public class MyInterfaceOrClass {
-
-
-    public JsonNode myMethod(JsonNode workflowData, KogitoProcessContext context ) {
+public JsonNode myMethod(JsonNode workflowData, KogitoProcessContext context ) {
         // do whatever I want with the JsonNode and the Kogito process context
         ......
         // return the modified content:
         return workflowData;
     }
 }
----- 
+----
 
 .Example of a function accessing Kogito context
 [source,java]
@@ -202,33 +200,41 @@ public class MyInterfaceOrClass {
 
 [WARNING]
 ====
-Avoid using `java` functions to call the external services, instead you can use the xref:service-orchestration/orchestration-of-openapi-based-services.adoc[services orchestration features].
+Avoid using `java` functions to call the external services, instead, you can use the xref:service-orchestration/orchestration-of-openapi-based-services.adoc[services orchestration features].
 ====
 
 == Custom function types
 
-You can add your own custom types by using the Kogito add-on mechanism. As predefined custom types like xref:core/custom-functions-support.adoc#con-func-sysout[`sysout`] or xref:core/custom-functions-support.adoc#con-func-java[`java`], the custom type identifier is the prefix of the operation field of the function definition. 
+You can add your custom types by using the Kogito add-on mechanism. As predefined custom types like xref:core/custom-functions-support.adoc#con-func-sysout[`sysout`] or xref:core/custom-functions-support.adoc#con-func-java[`java`], the custom type identifier is the prefix of the operation field of the function definition.
 
-Kogito add-ons relies on link:{quarkus_guides_base_url}/writing-extensions[Quarkus extensions] mechanism. And an add-on consists of at least two Maven projects:
+Kogito add-ons relies on the link:{quarkus_guides_base_url}/writing-extensions[Quarkus extensions] mechanism. And the add-on consists of at least two Maven projects:
 
-- the deployment module, which is responsible for generating code required for the extension to work.
-- the runtime module, which include the non generated classes that are required for the extension to work. 
+- The deployment module, which is responsible for generating the code required for the extension to work.
+- The runtime module, which includes the non-generated classes that are required for the extension to work.
 
-In the case of a serverless workflow custom type, here are the roles of the modules:
+In the case of a Serverless workflow custom type, following are the roles of the modules:
 
-- **The deployment project** is expected to configure the work item handler used during runtime to perform the logic associated with the custom type. +
-It must contain a Java class that inherits from `WorkItemTypeHandler`. Its responsibilities are to indicate the custom type identifier (the operation prefix, as indicated earlier) and to set up the `WorkItemNodeFactory` instance passed as a parameter of the `fillWorkItemHandler` method. That instance is included in the Kogito process definition for that Workflow. As part of this setup, you must indicate the name of the  `WorkItemNodeFactory`. You might also provide any relevant metadata for that handler if needed. 
-- **The runtime project** consists of a `WorkflowWorkItemHandler` implementation, which name must match the one provided to `WorkItemNodeFactory` during the deployment phase and a `WorkItemHandlerConfig` bean that register that handler with that name. +
- When a Serverless workflow function is called, Kogito identifies the proper `WorkflowWorkItemHandler` instance to be used for that function type (using the handler name associated with that type by the deployment project) and then invokes the `internalExecute` method. The `Map` parameter contains the function arguments defined in the Workflow, and the `WorkItem` parameter contains the metadata information added to the handler by the deployment project. Hence, the `executeWorkItem` implementation has access to all the information needed to perform the computational logic intended for that custom type. 
+- *The deployment project*
++
+The deployment project is expected to configure the work item handler used during runtime to perform the logic associated with the custom type.
+It must contain a Java class that inherits from `WorkItemTypeHandler`. Its responsibilities are to indicate the custom type identifier (the operation prefix, as indicated earlier) and to set up the `WorkItemNodeFactory` instance passed as a parameter of the `fillWorkItemHandler` method. That instance is included in the Kogito process definition for that Workflow. As a part of this setup, you must indicate the name of the  `WorkItemNodeFactory`. You might also provide any relevant metadata for that handler if needed.
 
+- *The runtime project*
++
+The runtime project consists of a `WorkflowWorkItemHandler` implementation, which name must match with the one provided to `WorkItemNodeFactory` during the deployment phase, and a `WorkItemHandlerConfig` bean that registers that handler with that name.
++
+When a Serverless workflow function is called, Kogito identifies the proper `WorkflowWorkItemHandler` instance to be used for that function type (using the handler name associated with that type by the deployment project) and then invokes the `internalExecute` method. The `Map` parameter contains the function arguments defined in the workflow, and the `WorkItem` parameter contains the metadata information added to the handler by the deployment project. Hence, the `executeWorkItem` implementation has an access to all the information needed to perform the computational logic intended for that custom type.
 
-=== Custom function type example. 
+=== Custom function type example
 
-Assuming you want to interact, from a workflow file, with a legacy RPC server as the one defined link:{kogito_sw_examples_url}/serverless-workflow-custom-type/serverless-workflow-custom-rpc-server[this project]. This legacy server supports four simple arithmetic operations: add, minus, multiply and divide, which can be invoked using a custom RPC protocol. Since this an uncommon protocol, the workflow cannot handle them by using any of the predefined Serverless Workflow function types. The available options are to use a Java Service, which invokes a Java class that knows how to interact with the server; or define a custom type that knows how to interact with the service. 
+Assuming you want to interact, from a workflow file, with a legacy RPC server as the one defined in link:{kogito_sw_examples_url}/serverless-workflow-custom-type/serverless-workflow-custom-rpc-server[this project]. This legacy server supports four simple arithmetic operations: add, minus, multiply and divide, which can be invoked using a custom RPC protocol.
 
-Using  the latter approach, users can write a link:{kogito_sw_examples_url}/serverless-workflow-custom-type/serverless-workflow-custom-type-example/src/main/resources/customType.sw.json[workflow file] defining this function. 
+Since this is an uncommon protocol, the workflow cannot handle them by using any of the predefined Serverless workflow function types. The available options are to use a Java service, which invokes a Java class that knows how to interact with the server, or define a custom type that knows how to interact with the service.
 
-.RPC Custom Function definition example
+Using the recent approach, you can write a link:{kogito_sw_examples_url}/serverless-workflow-custom-type/serverless-workflow-custom-type-example/src/main/resources/customType.sw.json[workflow file] defining this function.
+
+.RPC Custom function definition example
+
 [source,json]
 ----
  "functions": [
@@ -239,13 +245,15 @@ Using  the latter approach, users can write a link:{kogito_sw_examples_url}/serv
     }
   ],
 ----
-The `operation` starts with `rpc`, which is the custom type identifier, and continues with `division`, which denotes the operation that is going to be executed in the legacy server
 
-For this function definition to be recognized, a Kogito addon that defines the `rpc` custom type needs to be developed: it consists of a  link:{kogito_sw_examples_url}/serverless-workflow-custom-type/serverless-workflow-custom-rpc-deployment[deployment project] and a link:{kogito_sw_examples_url}/serverless-workflow-custom-type/serverless-workflow-custom-rpc[runtime project].
+The `operation` starts with `rpc`, which is the custom type identifier, and continues with `division`, which denotes the operation that is going to be executed in the legacy server.
 
-The deployment project is responsible for extending link:{kogito_sw_examples_url}/serverless-workflow-custom-type/serverless-workflow-custom-rpc-deployment/src/main/java/org/kie/kogito/examples/sw/services/RPCCustomTypeHandler.java[`WorkItemTypeHandler`] and setup the `WorkItemNodeFactory`:
+For this function definition to be identified, a Kogito addon that defines the `rpc` custom type must be developed. It is consist of a link:{kogito_sw_examples_url}/serverless-workflow-custom-type/serverless-workflow-custom-rpc-deployment[deployment project] and a link:{kogito_sw_examples_url}/serverless-workflow-custom-type/serverless-workflow-custom-rpc[runtime project].
 
-.Example of the RPC Function Java implementation
+The deployment project is responsible for extending the link:{kogito_sw_examples_url}/serverless-workflow-custom-type/serverless-workflow-custom-rpc-deployment/src/main/java/org/kie/kogito/examples/sw/services/RPCCustomTypeHandler.java[`WorkItemTypeHandler`] and setup the `WorkItemNodeFactory` as follows:
+
+.Example of the RPC function Java implementation
+
 [source,java]
 ----
 
@@ -259,14 +267,15 @@ import static org.kie.kogito.examples.sw.custom.RPCCustomWorkItemHandler.OPERATI
         return node.workName(NAME).metaData(OPERATION, trimCustomOperation(functionDef));
     }
 ----
+
 This example setups the name of the `KogitoWorkItemHandler` and adds a metadata key that extracts the name of the operation to perform in the legacy server from the Serverless workflow function definition.
 
-The Runtime project contains the link:{kogito_sw_examples_url}/serverless-workflow-custom-type/serverless-workflow-custom-rpc/src/main/java/org/kie/kogito/examples/sw/custom/RPCCustomWorkItemHandler.java[KogitoWorkItemHandler] and the {kogito_sw_examples_url}/serverless-workflow-custom-type/serverless-workflow-custom-rpc/src/main/java/org/kie/kogito/examples/sw/custom/RPCCustomWorkItemHandlerConfig.java[WorkItemHandlerConfig] implementations. 
+The Runtime project contains the link:{kogito_sw_examples_url}/serverless-workflow-custom-type/serverless-workflow-custom-rpc/src/main/java/org/kie/kogito/examples/sw/custom/RPCCustomWorkItemHandler.java[KogitoWorkItemHandler] and the link:{kogito_sw_examples_url}/serverless-workflow-custom-type/serverless-workflow-custom-rpc/src/main/java/org/kie/kogito/examples/sw/custom/RPCCustomWorkItemHandlerConfig.java[WorkItemHandlerConfig] implementations.
 
-
-As expected, `RPCCustomWorkItemHandler` implements the `internalExecute` method:
+As expected, `RPCCustomWorkItemHandler` implements the `internalExecute` method as follows:
 
 .Example of implementation of the `internalExecute` method
+
 [source, java]
 ----
  @Override
@@ -278,7 +287,7 @@ protected Object internalExecute(KogitoWorkItem workItem, Map<String, Object> pa
         if (operationId == null) {
             throw new IllegalArgumentException ("Operation is a mandatory parameter");
         }
-        return CalculatorClient.invokeOperation((String)metadata.getOrDefault(HOST,"localhost"), (int) metadata.getOrDefault(PORT, 8082), 
+        return CalculatorClient.invokeOperation((String)metadata.getOrDefault(HOST,"localhost"), (int) metadata.getOrDefault(PORT, 8082),
                 OperationId.valueOf(operationId.toUpperCase()), (Integer)iter.next(), (Integer)iter.next());
     } catch (IOException io ) {
         throw new UncheckedIOException(io);
@@ -286,9 +295,10 @@ protected Object internalExecute(KogitoWorkItem workItem, Map<String, Object> pa
 }
 ----
 
-The implementation invokes link:{kogito_sw_examples_url}/serverless-workflow-custom-type/serverless-workflow-custom-rpc-server/src/main/java/org/kie/kogito/examples/sw/custom/CalculatorClient.java#L45-L67[`CalculatorClient.invokeOperation`], a java static method that knows how to interact with the legacy service. The operation parameter is obtained from the `WorkItem` metadata. Dividend and divisor parameters are obtained from the Map parameter, which contains the function arguments defined in the workflow file.
+The implementation invokes the link:{kogito_sw_examples_url}/serverless-workflow-custom-type/serverless-workflow-custom-rpc-server/src/main/java/org/kie/kogito/examples/sw/custom/CalculatorClient.java#L45-L67[`CalculatorClient.invokeOperation`], a java static method that knows how to interact with the legacy service. You can obtain the operation parameter from the `WorkItem` metadata. The dividend and the divisor parameters are obtained from the Map parameter, which contains the function arguments defined in the workflow file.
 
 .Example of the custom function call from the workflow definition
+
 [source, json]
 ----
 "actions": [
@@ -300,13 +310,14 @@ The implementation invokes link:{kogito_sw_examples_url}/serverless-workflow-cus
                  "divisor" : ".divisor"
              }
            }
-          
+
        }
 ----
 
-The `RPCCustomWorkItemHandlerConfig` is a bean that registers the handler name
+The `RPCCustomWorkItemHandlerConfig` is a bean that registers the handler name.
 
 .Example of injecting the custom`WorkItemHandler`
+
 [source, java]
 ----
 @Inject


### PR DESCRIPTION
<!-- Please don't forget your JIRA link -->
**JIRA:[KOGITO-8078](https://issues.redhat.com/browse/KOGITO-8078)**

<!-- If you don't have a JIRA link, please provide a short description of what this PR does -->
**Description:** I reviewed the content for the **Custom function types** section and added my suggestions. Please take a look and reach out to me if you have any questions.

<!-- Link to related PRs: -->

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributions doc](https://github.com/kiegroup/kogito-docs/blob/main/CONTRIBUTING.md)
- [ ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [ ] The nav.adoc file has a link to this guide in the proper category
- [ ] The index.adoc file has a card to this guide in the proper category, with a meaningful description

<details>
<summary>
How to setup automatic cherry-pick to another branch ?
</summary>

The cherry-pick action allows to setup automatic cherry-pick from `main` to a specific branch.

To allow it, you will need to add the corresponding label with pattern: `backport-{RELEASE_BRANCH}`.  
For example, if a backport to branch `1.26.x` is needed, then the label should be `backport-1.26.x`.

Once the PR is merged, the action will retrieve the commit and cherry-pick it to the desired branch.

*NOTE: You can still add label after the merge and it should still be cherry-picked.*
</details>