### PR TITLE
[KOGITO-8281] - Adding redirects from version number to 'latest'

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -3,6 +3,8 @@ site:
   start_page: serverlessworkflow::index.adoc
 urls:
   latest_version_segment: latest
+  latest_version_segment_strategy: redirect:to
+  redirect_facility: netlify
 antora:
   extensions:
   - require: '@antora/lunr-extension'


### PR DESCRIPTION
Signed-off-by: Ricardo Zanini <zanini@redhat.com>

<!-- Please don't forget your JIRA link -->
**JIRA:** https://issues.redhat.com/browse/KOGITO-8281

<!-- If you don't have a JIRA link, please provide a short description of what this PR does -->
**Description:**
Documentation references:
- https://docs.antora.org/antora/latest/playbook/urls-redirect-facility/
- https://docs.antora.org/antora/latest/playbook/urls-latest-version-segment-strategy/

<!-- Link to related PRs: -->

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributions doc](https://github.com/kiegroup/kogito-docs/blob/main/CONTRIBUTING.md)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [x] The nav.adoc file has a link to this guide in the proper category
- [x] The index.adoc file has a card to this guide in the proper category, with a meaningful description

<details>
<summary>
How to setup automatic cherry-pick to another branch ?
</summary>

The cherry-pick action allows to setup automatic cherry-pick from `main` to a specific branch.

To allow it, you will need to add the corresponding label with pattern: `backport-{RELEASE_BRANCH}`.  
For example, if a backport to branch `1.26.x` is needed, then the label should be `backport-1.26.x`.

Once the PR is merged, the action will retrieve the commit and cherry-pick it to the desired branch.

*NOTE: You can still add label after the merge and it should still be cherry-picked.*
</details>