### PR TITLE
[KOGITO-8141][KOGITO-8309] - Enhancing Knative Eventing guide with info about local testing

### DIFF
--- a/serverlessworkflow/antora.yml
+++ b/serverlessworkflow/antora.yml
@@ -46,6 +46,7 @@ asciidoc:
     spec_doc_url: https://github.com/serverlessworkflow/specification/blob/0.8.x/specification.md
     cloud_events_url: https://cloudevents.io/
     cloud_events_sdk_url: https://github.com/cloudevents/sdk-java
+    cloud_events_git_url: https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents
     open_api_spec_url: https://spec.openapis.org/oas/v3.1.0.html
     quarkus_openapi_gen_url: https://github.com/quarkiverse/quarkus-openapi-generator
     kie_tools_releases_page_url: https://github.com/kiegroup/kie-tools/releases

--- a/serverlessworkflow/modules/ROOT/pages/eventing/consume-produce-events-with-knative-eventing.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/eventing/consume-produce-events-with-knative-eventing.adoc
@@ -154,7 +154,53 @@ The following table lists the configuration property related to Knative sink gen
 |`default`
 |This property indicates the name of the default Knative broker that is deployed in the Kubernetes namespace. This broker is used as the reference to create the Knative triggers, which are responsible to delegate the events that the workflow service consumes.
 
+| `mp.messaging.incoming.kogito_incoming_stream.path`
+| `/` (root path)
+|This property indicates the HTTP path where the workflow application will listen for the CloudEvents in the default incoming channel.
+
+| `mp.messaging.incoming.<event type name>.path`
+| `/` (root path)
+| This property indicates the HTTP path where the workflow application will listen for the CloudEvents in the specific given channel name. The channel name is the event `type` as defined in the Serverless Workflow events definition.
+
 |===
+
+[[proc-manually-sending-events-to-an-http-endpoint]]
+== Manually sending events to an HTTP endpoint
+
+You can send HTTP CloudEvents to the workflow application endpoint by using any tool that's capable to produce HTTP requests. The only requirement is that the request conforms to the link:{cloud_events_git_url}/spec.md#message[CloudEvents specification].
+
+For example, using `curl`, you can send an event to the workflow using the following command:
+
+.Sending a CloudEvent over HTTP using the structured format.
+[source,shell]
+----
+curl -X POST \
+     -H 'Content-Type: application/cloudevents+json'  \
+     -d '{"datacontenttype": "application/json", "specversion":"1.0","id":"41495513-a9ef-4a81-8479-21bb14db61f0","source":"/local/curl","type":"kogito.serverless.loanbroker.aggregated.quotes.response","data": { "amount": 300000, "term": 30, "credit": { "score": 700, "history": 15 }, "quotes": [{ "bankId": "Bank1", "rate": 12.2  }, {"bankId": "Bank2", "rate": 10}]  } } ' \
+http://localhost:8080
+----
+
+In this example we are using the link:{cloud_events_git_url}/bindings/http-protocol-binding.md#32-structured-content-mode[CloudEvents structured format], which includes every event information within the request payload. Note the header `Content-Type` being `application/cloudevents+json`.
+
+Alternatively, you can use the link:{cloud_events_git_url}/bindings/http-protocol-binding.md#31-binary-content-mode[CloudEvents binary format], which includes the event metadata in the HTTP header. For example, using the same event as before:
+
+.Sending a CloudEvent over HTTP using the binary format.
+[source,shell]
+----
+curl -X POST -i \
+     -H 'Content-Type: application/json'  \
+     -H 'ce-specversion: 1.0' \
+     -H 'ce-id: 41495513-a9ef-4a81-8479-21bb14db61f0' \
+     -H 'ce-source: /local/curl' \
+     -H 'ce-type: kogito.serverless.loanbroker.aggregated.quotes.response' \
+     -d '{ "amount": 300000, "term": 30, "credit": { "score": 700, "history": 15 }, "quotes": [{ "bankId": "Bank1", "rate": 12.2  }, {"bankId": "Bank2", "rate": 10}]  }' \
+http://localhost:8080/
+----
+
+You can use this tool to test your {product_name} application locally and verify if the events are being consumed correctly by the workflow.
+
+To know more about testing incomming and outgoing CloudEvents over HTTP refer to the guide xref:testing-and-troubleshooting/mocking-http-cloudevents-with-wiremock.adoc[Mocking HTTP CloudEvents sink using WireMock].
+
 
 [[proc-generating-kn-objects-build-time]]
 == Generating Knative objects during build time

--- a/serverlessworkflow/modules/ROOT/pages/eventing/consume-produce-events-with-knative-eventing.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/eventing/consume-produce-events-with-knative-eventing.adoc
@@ -169,7 +169,7 @@ The following table lists the configuration property related to Knative sink gen
 
 You can send HTTP CloudEvents to the workflow application endpoint by using any tool that's capable to produce HTTP requests. The only requirement is that the request conforms to the link:{cloud_events_git_url}/spec.md#message[CloudEvents specification].
 
-For example, using `curl`, you can send an event to the workflow using the following command:
+For example, with the help of  `curl`, you can send an event to the workflow using the following command:
 
 .Sending a CloudEvent over HTTP using the structured format.
 [source,shell]
@@ -199,7 +199,7 @@ http://localhost:8080/
 
 You can use this tool to test your {product_name} application locally and verify if the events are being consumed correctly by the workflow.
 
-To know more about testing incomming and outgoing CloudEvents over HTTP refer to the guide xref:testing-and-troubleshooting/mocking-http-cloudevents-with-wiremock.adoc[Mocking HTTP CloudEvents sink using WireMock].
+For more information about testing incoming and outgoing CloudEvents over HTTP, see xref:testing-and-troubleshooting/mocking-http-cloudevents-with-wiremock.adoc[Mocking HTTP CloudEvents sink using WireMock].
 
 
 [[proc-generating-kn-objects-build-time]]


### PR DESCRIPTION
Adding more information to the guides, see:

- [Update Knative Eventing Serverless Workflow Guide to add Incoming HTTP configuration](https://issues.redhat.com/browse/KOGITO-8141)
- [Improve Knative Eventing doc by adding an example how to send and consume HTTP events](https://issues.redhat.com/browse/KOGITO-8309)

Signed-off-by: Ricardo Zanini <zanini@redhat.com>

<!-- Please don't forget your JIRA link -->
**JIRA:**

<!-- If you don't have a JIRA link, please provide a short description of what this PR does -->
**Description:**

<!-- Link to related PRs: -->

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributions doc](https://github.com/kiegroup/kogito-docs/blob/main/CONTRIBUTING.md)
- [ ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [ ] The nav.adoc file has a link to this guide in the proper category
- [ ] The index.adoc file has a card to this guide in the proper category, with a meaningful description

<details>
<summary>
How to setup automatic cherry-pick to another branch ?
</summary>

The cherry-pick action allows to setup automatic cherry-pick from `main` to a specific branch.

To allow it, you will need to add the corresponding label with pattern: `backport-{RELEASE_BRANCH}`.  
For example, if a backport to branch `1.26.x` is needed, then the label should be `backport-1.26.x`.

Once the PR is merged, the action will retrieve the commit and cherry-pick it to the desired branch.

*NOTE: You can still add label after the merge and it should still be cherry-picked.*
</details>