### PR TITLE
[KOGITO-8353] Introduce Camel Routes integration guide

### DIFF
--- a/serverlessworkflow/antora.yml
+++ b/serverlessworkflow/antora.yml
@@ -80,3 +80,5 @@ asciidoc:
     camel_url: https://camel.apache.org/
     # must align this version
     camel_extensions_url: https://camel.apache.org/camel-quarkus/2.14.x/reference/extensions
+    kaoto_url: https://marketplace.visualstudio.com/items?itemName=redhat.vscode-kaoto
+

--- a/serverlessworkflow/antora.yml
+++ b/serverlessworkflow/antora.yml
@@ -77,3 +77,6 @@ asciidoc:
     openshift_application_data_services_service_account_url: https://console.redhat.com/application-services/service-accounts
     openshift_application_data_services_service_registry_url: https://console.redhat.com/application-services/service-registry
     openshift_application_data_services_apache_kafka_url: https://console.redhat.com/application-services/streams/kafkas
+    camel_url: https://camel.apache.org/
+    # must align this version
+    camel_extensions_url: https://camel.apache.org/camel-quarkus/2.14.x/reference/extensions

--- a/serverlessworkflow/modules/ROOT/nav.adoc
+++ b/serverlessworkflow/modules/ROOT/nav.adoc
@@ -59,6 +59,7 @@
 // ** xref:cloud/versioning-workflows-in-knative.adoc[Versioning workflows in Knative]
 ** xref:cloud/kubernetes-service-discovery.adoc[Kubernetes service discovery in {context}]
 * Integrations
+** xref:integrations/camel-routes-integration.adoc[Integrating with Camel Routes]
 ** xref:integrations/expose-metrics-to-prometheus.adoc[Exposing workflow base metrics to Prometheus]
 // ** xref:integrations/camel-k-integration.adoc[Integrating with Camel-K]
  ** xref:integrations/serverless-dashboard-with-runtime-data.adoc[Displaying workflow data in dashboards]

--- a/serverlessworkflow/modules/ROOT/pages/_common-content/camel-valid-responses.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/_common-content/camel-valid-responses.adoc
@@ -1,5 +1,5 @@
 :page-partial:
-1. A valid JSON string
+1. A string that contains a valid JSON object
 2. A valid Java bean that can be serialized to JSON
 3. A Jackson's `JsonNode` object
 4. Any primitive type (Integer, Float, Decimal, String, etc)

--- a/serverlessworkflow/modules/ROOT/pages/_common-content/camel-valid-responses.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/_common-content/camel-valid-responses.adoc
@@ -1,0 +1,5 @@
+:page-partial:
+1. A valid JSON string
+2. A valid Java bean that can be serialized to JSON
+3. A Jackson's `JsonNode` object
+4. Any primitive type (Integer, Float, Decimal, String, etc)

--- a/serverlessworkflow/modules/ROOT/pages/core/custom-functions-support.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/core/custom-functions-support.adoc
@@ -207,9 +207,9 @@ Avoid using `java` functions to call the external services, instead, you can use
 
 Kogito supports the link:{camel_url}[Camel Routes] functions within an Apache Maven project, in which you define your workflow service.
 
-[TIP]
+[NOTE]
 ====
-NOTE: This section briefly exemplifies how to define and use Camel Routes within your workflow application. For more information, see the xref:integrations/camel-routes-integration.adoc[Integrating with Camel Routes].
+This section briefly exemplifies how to define and use Camel Routes within your workflow application. For more information, see the xref:integrations/camel-routes-integration.adoc[Integrating with Camel Routes].
 ====
 
 === Function definition

--- a/serverlessworkflow/modules/ROOT/pages/core/custom-functions-support.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/core/custom-functions-support.adoc
@@ -15,7 +15,7 @@ The CNCF specification does not support `java` and `sysout` functions. Therefore
 ====
 
 [[con-func-sysout]]
-== Sysout Custom Function
+== Sysout custom function
 
 You can use the `sysout` function for debugging or for quick demonstrations as shown in the following example:
 
@@ -65,7 +65,7 @@ You must avoid using the `sysout` function in a production environment since it 
 ====
 
 [[con-func-java]]
-== Java Custom Function
+== Java custom function
 
 {product_name} supports the `java` functions within an Apache Maven project, in which you define your workflow service.
 
@@ -203,16 +203,16 @@ public class MyInterfaceOrClass {
 Avoid using `java` functions to call the external services, instead, you can use the xref:service-orchestration/orchestration-of-openapi-based-services.adoc[services orchestration features].
 ====
 
-== Camel Custom Function
+== Camel custom function
 
 Kogito supports the link:{camel_url}[Camel Routes] functions within an Apache Maven project, in which you define your workflow service.
 
 [TIP]
 ====
-This section brefly exemplify how to define and use Camel Routes within your workflow application. For a more in-depth guide, please see the xref:integrations/camel-routes-integration.adoc[Integrating with Camel Routes].
+NOTE: This section briefly exemplifies how to define and use Camel Routes within your workflow application. For more information, see the xref:integrations/camel-routes-integration.adoc[Integrating with Camel Routes].
 ====
 
-=== Function Definition
+=== Function definition
 
 The following example shows the declaration of a Camel function:
 
@@ -233,11 +233,11 @@ The following example shows the declaration of a Camel function:
 <2> `custom` is the function type
 <3> `camel:direct:myendpoint` is the custom operation definition. In this definition, `camel` is the reserved keyword followed by the `direct` endpoint. link:{camel_extensions_url}/direct.html[Camel Direct] is the only supported consumer by {context}. Finally, `myendpoint` is the endpoint URI name found in the route within your project's context.
 
-=== Function Arguments
+=== Function arguments
 
-The Camel function arguments must follow a specific structure when passing data from the workflow state to the route. The only attributes supported in the function arguments are `body` and `headers`. Both are optional if you need to call the Camel routes without arguments. The only constraint is that you can't call a Camel route with only `headers`.
+The Camel function arguments must follow a specific structure when passing data from the workflow state to the route. The `body` and `headers` are the only attributes supported in the function arguments. Both are optional if you need to call the Camel routes without arguments. The only constraint is that you can not call a Camel route with only `headers`.
 
-Following the examples of valid arguments structures for Camel function arguments.
+The following examples display valid argument structures for Camel function arguments:
 
 .Example calling a Camel route using `body` and `headers`
 [source,json]
@@ -297,11 +297,11 @@ In this last example, the `jq` expression result is used as the `body` argument 
 
 === Function return values
 
-The Camel route is reponsible to produce the return value in a way that the workflow can understand. That following are considered valid objects:
+The Camel route is responsible to produce the return value in a way that the workflow can understand. The following are considered valid objects:
 
 include::../../pages/_common-content/camel-valid-responses.adoc[]
 
-== Custom Function Types
+== Custom function types
 
 You can add your custom types by using the Kogito add-on mechanism. As predefined custom types like xref:core/custom-functions-support.adoc#con-func-sysout[`sysout`] or xref:core/custom-functions-support.adoc#con-func-java[`java`], the custom type identifier is the prefix of the operation field of the function definition.
 

--- a/serverlessworkflow/modules/ROOT/pages/core/custom-functions-support.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/core/custom-functions-support.adoc
@@ -15,7 +15,7 @@ The CNCF specification does not support `java` and `sysout` functions. Therefore
 ====
 
 [[con-func-sysout]]
-== `sysout` custom function
+== Sysout Custom Function
 
 You can use the `sysout` function for debugging or for quick demonstrations as shown in the following example:
 
@@ -65,7 +65,7 @@ You must avoid using the `sysout` function in a production environment since it 
 ====
 
 [[con-func-java]]
-== `java` custom function
+== Java Custom Function
 
 {product_name} supports the `java` functions within an Apache Maven project, in which you define your workflow service.
 
@@ -108,6 +108,7 @@ For example, if you invoke a function using one argument as follows, then your m
      "number": "${.number}"
    }
  }
+}
 ----
 
 
@@ -143,7 +144,6 @@ When using the following example function reference with no arguments, and if th
 [source,java]
 ----
 public class MyInterfaceOrClass {
-
 
     public JsonNode myMethod(JsonNode workflowData) {
         // do whatever I want with the Workflow model
@@ -203,7 +203,101 @@ public class MyInterfaceOrClass {
 Avoid using `java` functions to call the external services, instead, you can use the xref:service-orchestration/orchestration-of-openapi-based-services.adoc[services orchestration features].
 ====
 
-== Custom function types
+== Camel Custom Function
+
+Kogito supports the link:{camel_url}[Camel Routes] functions within an Apache Maven project, in which you define your workflow service.
+
+[TIP]
+====
+This section brefly exemplify how to define and use Camel Routes within your workflow application. For a more in-depth guide, please see the xref:integration/camel-routes-integration.adoc[Integrating with Camel Routes].
+====
+
+=== Function Definition
+
+The following example shows the declaration of a Camel function:
+
+[source,json]
+----
+{
+  "functions": [
+    {
+      "name": "myCamelEndpoint", <1>
+      "type": "custom",  <2>
+      "operation": "camel:direct:myendpoint" <3>
+    }
+  ]
+}
+----
+
+<1> `myCamelEndpoint` is the function name
+<2> `custom` is the function type
+<3> `camel:direct:myendpoint` is the custom operation definition. In this definition, `camel` is the reserved keyword followed by the `direct` endpoint. link:{camel_extensions_url}/direct.html[Camel Direct] is the only supported consumer by {context}. Finally, `myendpoint` is the endpoint URI name found in the route within your project's context.
+
+=== Function Arguments
+
+The Camel function arguments must follow a specific structure when passing data from the workflow state to the route. The only attributes supported in the function arguments are `body` and `headers`. Both are optional if you need to call the Camel routes without arguments. The only constraint is that you can't call a Camel route with only `headers`.
+
+Following the examples of valid arguments structures for Camel function arguments.
+
+.Example calling a Camel route using `body` and `headers`
+[source,json]
+----
+{
+  "functionRef": {
+    "refName": "myCamelEndpoint",
+    "arguments": {
+      "body": "${ .my.body.data }", <1>
+      "headers": { <2>
+        "key1": "${ .my.value }",
+        "key2": "${ .my.other.value }"
+      }
+    }
+  }
+}
+----
+
+<1> `jq` expression filtering the state data for the `body` argument.
+<2> JSON key/value pair for the `headers` argument. A `jq` expression returning the same JSON object is also valid.
+
+.Example calling a Camel route using `body`
+[source,json]
+----
+{
+  "functionRef": {
+    "refName": "myCamelEndpoint",
+    "arguments": {
+      "body": "${ .my.body.data }"
+    }
+  }
+}
+----
+
+.Example calling a Camel route without arguments
+[source,json]
+----
+{
+  "functionRef": {
+    "refName": "myCamelEndpoint"
+  }
+}
+----
+
+.Example calling a Camel route with only one argument
+[source,json]
+----
+{
+  "functionRef": {
+    "refName": "myCamelEndpoint",
+    "arguments": "${ .my.body,data }"
+  }
+}
+----
+
+In this last example, the `jq` expression result is used as the `body` argument in a way to simplify the definition.
+
+=== Function return values
+
+== Custom Function Types
 
 You can add your custom types by using the Kogito add-on mechanism. As predefined custom types like xref:core/custom-functions-support.adoc#con-func-sysout[`sysout`] or xref:core/custom-functions-support.adoc#con-func-java[`java`], the custom type identifier is the prefix of the operation field of the function definition.
 
@@ -312,17 +406,19 @@ The implementation invokes the link:{kogito_sw_examples_url}/serverless-workflow
 
 [source, json]
 ----
-"actions": [
-       {
-          "functionRef": {
-             "refName": "division",
-             "arguments": {
-                 "dividend": ".dividend",
-                 "divisor" : ".divisor"
-             }
-           }
-
-       }
+{
+  "actions":[
+    {
+      "functionRef":{
+        "refName":"division",
+        "arguments":{
+          "dividend":".dividend",
+          "divisor":".divisor"
+        }
+      }
+    }
+  ]
+}
 ----
 
 The `RPCCustomWorkItemHandlerConfig` is a bean that registers the handler name.
@@ -339,7 +435,6 @@ void init () {
     register(handler.getName(),handler);
 }
 ----
-
 
 == Additional resources
 

--- a/serverlessworkflow/modules/ROOT/pages/core/custom-functions-support.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/core/custom-functions-support.adoc
@@ -209,7 +209,7 @@ Kogito supports the link:{camel_url}[Camel Routes] functions within an Apache Ma
 
 [TIP]
 ====
-This section brefly exemplify how to define and use Camel Routes within your workflow application. For a more in-depth guide, please see the xref:integration/camel-routes-integration.adoc[Integrating with Camel Routes].
+This section brefly exemplify how to define and use Camel Routes within your workflow application. For a more in-depth guide, please see the xref:integrations/camel-routes-integration.adoc[Integrating with Camel Routes].
 ====
 
 === Function Definition
@@ -288,7 +288,7 @@ Following the examples of valid arguments structures for Camel function argument
 {
   "functionRef": {
     "refName": "myCamelEndpoint",
-    "arguments": "${ .my.body,data }"
+    "arguments": "${ .my.body.data }"
   }
 }
 ----
@@ -296,6 +296,10 @@ Following the examples of valid arguments structures for Camel function argument
 In this last example, the `jq` expression result is used as the `body` argument in a way to simplify the definition.
 
 === Function return values
+
+The Camel route is reponsible to produce the return value in a way that the workflow can understand. That following are considered valid objects:
+
+include::../../pages/_common-content/camel-valid-responses.adoc[]
 
 == Custom Function Types
 

--- a/serverlessworkflow/modules/ROOT/pages/index.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/index.adoc
@@ -308,6 +308,14 @@ Learn how and when to use the SAGA pattern in your workflow projects
 [.card]
 --
 [.card-title]
+xref:integrations/camel-routes-integration.adoc[Integrating with Camel Routes]
+[.card-description]
+Learn how to use Camel Routes within your workflow application
+--
+
+[.card]
+--
+[.card-title]
 xref:integrations/serverless-dashboard-with-runtime-data.adoc[Displaying workflow data in dashboards]
 [.card-description]
 Learn how to use dashboards to display the runtime data of your workflow application

--- a/serverlessworkflow/modules/ROOT/pages/integrations/camel-routes-integration.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/integrations/camel-routes-integration.adoc
@@ -1,1 +1,133 @@
 = Integrating with Camel Routes
+
+{context} can integrate with link:{camel_url}[Apache Camel Routes] by adding the Kogito Quarkus Camel Add-on to your project. It enables the workflow engine to identify and call Camel Routes declared in YAML or XML in the same workflow project context.
+
+[[proc-enable-quarkus-camel]]
+== Enabling Quarkus Camel in {context}
+
+You can enable Quarkus Camel in your project.
+
+.Prerequisites
+* A workflow application is created. 
++
+For more information about creating a workflow, see xref:getting-started/create-your-first-workflow-service.adoc[Creating your first workflow service].
+
+.Procedure
+. To add the Quarkus Camel to your workflow application, add the `org.kie.kogito:kogito-addons-quarkus-camel` dependency to the `pom.xml` file of your project:
++
+--
+.Dependency to be added to the `pom.xml` file to enable metrics
+[source,xml]
+----
+<dependency>
+    <groupId>org.kie.kogito</groupId>
+    <artifactId>kogito-addons-quarkus-camel</artifactId>
+</dependency>
+----
+--
+
+[[con-creating-camel-routes]]
+== Creating Camel Routes in {context}
+
+You can add YAML or XML Camel Routes in your workflow project.
+
+.Procedure
+. Create a YAML or XML Camel Routes using your IDE or the link:{kaoto_url}[Kaoto VSCode Editor] and place them in the `src/main/resources/routes` directory.
+. The route `from` endpoint *must* be a `direct` component. That's the endpoint producer expected by the workflow engine.
+. The route response must be in a valid format that the workflow context can understand:
++
+include::../../pages/_common-content/camel-valid-responses.adoc[]
++
+The response will be merged to the workflow state context. If it's an array or a complex object, the response will be added to the special attribute `response`.
+
+.Example of a Camel Route with the `direct` endpoint returning a valid JSON string representation
+[source,yaml]
+----
+- from:
+    uri: direct:logRouteReplaceHeader
+    steps:
+      - setBody:
+          simple: '{ "id": "${header.WorkflowID}", "arg1": { "arg2": "value1" } }'
+      - log:
+          message: We received the ${body}
+----
+
+[[con-importing-camel-routes]]
+== Defining and Referencing Camel functions in the Workflow DSL
+
+You can define and reference your Camel functions in the workflow definition.
+
+.Prerequisites
+* You have created Camel Routes in the workflow Maven project.
+
+.Procedure
+. In the `functions` definition section of your workflow DSL, declare the Camel Route like exemplified below:
++
+.Example of a Camel Route function definition
+[source,json]
+----
+{
+  "functions": [
+    {
+      "name": "logRoute",
+      "type": "custom",
+      "operation": "camel:direct:logRouteReplaceHeader"
+    }
+  ]
+}
+----
++
+The operation description must have the prefix `camel:direct:`, indicating that you want to produce a message to this route via the link:{camel_extensions_url}/direct.html[Camel Direct Component]. Direct is the only component supported by {context} at the moment.
++
+The `operation` suffix contains the name of the route endpoint. In the case of this example, `logRouteReplaceHeader`.
+
+[WARNING]
+====
+The Camel Route defined in the workflow must be available in your project during runtime, otherwise an `IllegalArgumentException` will thrown.
+====
+
+. To use the Camel function definition in a workflow action, you can simply reference to it as you normally would with any other {context} function definitions. For example:
++
+.Example of a workflow state action referencing
+[source,json]
+----
+{
+  "states": [
+    {
+      "name": "sendToLog",
+      "type": "operation",
+      "actions": [
+        {
+          "functionRef": {
+            "refName": "logRoute", <1>
+            "arguments": {
+              "body": "${ . }", <2>
+              "headers": {
+                "WorkflowID": "$WORKFLOW.instanceId" <3>
+              }
+            }
+          }
+        }
+      ],
+      "end": true
+    }
+  ]
+}
+----
++
+<1> The function reference name, as defined in the function attribute.
+<2> The body definition. A `jq` expression to be evaluated in runtime resulting in the body payload.
+<3> The `headers` definition that must be a key/value pair or a valid `jq` expression evaluated in runtime.
+
+Once a message is received back from the Camel route, the data is merged to the workflow payload.
+
+== Example Project
+
+There's an link:{kogito_sw_examples_url}/serverless-workflow-camel-routes[example project available on GitHub] using this new feature. You can use it as a reference to have a better understanding of the Camel integration with {context}.
+
+== Additional resources
+
+* xref:core/custom-functions-support[Custom functions for your {context} service]
+* xref:core/understanding-jq-expressions.adoc[jq expressions in {context}]
+
+include::../../pages/_common-content/report-issue.adoc[]

--- a/serverlessworkflow/modules/ROOT/pages/integrations/camel-routes-integration.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/integrations/camel-routes-integration.adoc
@@ -1,0 +1,1 @@
+= Integrating with Camel Routes

--- a/serverlessworkflow/modules/ROOT/pages/integrations/camel-routes-integration.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/integrations/camel-routes-integration.adoc
@@ -1,6 +1,6 @@
-= Integrating with Camel Routes
+= Integrating with Camel routes
 
-{context} can integrate with link:{camel_url}[Apache Camel Routes] by adding the Kogito Quarkus Camel Add-on to your project. It enables the workflow engine to identify and call Camel Routes declared in YAML or XML in the same workflow project context.
+{context} can integrate with link:{camel_url}[Apache Camel Routes] by adding the Kogito Quarkus Camel Add-on to your project. It enables the workflow engine to identify and call Camel routes declared in YAML or XML in the same workflow project context.
 
 [[proc-enable-quarkus-camel]]
 == Enabling Quarkus Camel in {context}
@@ -13,7 +13,7 @@ You can enable Quarkus Camel in your project.
 For more information about creating a workflow, see xref:getting-started/create-your-first-workflow-service.adoc[Creating your first workflow service].
 
 .Procedure
-. To add the Quarkus Camel to your workflow application, add the `org.kie.kogito:kogito-addons-quarkus-camel` dependency to the `pom.xml` file of your project:
+. To add the Quarkus Camel to your workflow application, add the `org.kie.kogito:kogito-addons-quarkus-camel` dependency to the `pom.xml` file of your project as follows:
 +
 --
 .Dependency to be added to the `pom.xml` file to enable metrics
@@ -27,20 +27,20 @@ For more information about creating a workflow, see xref:getting-started/create-
 --
 
 [[con-creating-camel-routes]]
-== Creating Camel Routes in {context}
+== Creating Camel routes in {context}
 
-You can add YAML or XML Camel Routes in your workflow project.
+You can add YAML or XML Camel routes to your workflow project.
 
 .Procedure
 . Create a YAML or XML Camel Routes using your IDE or the link:{kaoto_url}[Kaoto VSCode Editor] and place them in the `src/main/resources/routes` directory.
-. The route `from` endpoint *must* be a `direct` component. That's the endpoint producer expected by the workflow engine.
+. The route `from` endpoint must be a `direct` component. That's the endpoint producer expected by the workflow engine.
 . The route response must be in a valid format that the workflow context can understand:
 +
 include::../../pages/_common-content/camel-valid-responses.adoc[]
 +
-The response will be merged to the workflow state context. If it's an array or a complex object, the response will be added to the special attribute `response`.
+The response will be merged into the workflow state context. If it is an array or a complex object, the response will be added to the special attribute `response`.
 
-.Example of a Camel Route with the `direct` endpoint returning a valid JSON string representation
+.Example of a Camel route with the `direct` endpoint returning a valid JSON string representation
 [source,yaml]
 ----
 - from:
@@ -53,15 +53,15 @@ The response will be merged to the workflow state context. If it's an array or a
 ----
 
 [[con-importing-camel-routes]]
-== Defining and Referencing Camel functions in the Workflow DSL
+== Defining and referencing Camel functions in the Workflow DSL
 
 You can define and reference your Camel functions in the workflow definition.
 
 .Prerequisites
-* You have created Camel Routes in the workflow Maven project.
+* You have created Camel routes in the workflow Maven project.
 
 .Procedure
-. In the `functions` definition section of your workflow DSL, declare the Camel Route like exemplified below:
+. In the `functions` definition section of your workflow DSL, declare the Camel route as exemplified below:
 +
 .Example of a Camel Route function definition
 [source,json]
@@ -83,10 +83,10 @@ The `operation` suffix contains the name of the route endpoint. In the case of t
 
 [WARNING]
 ====
-The Camel Route defined in the workflow must be available in your project during runtime, otherwise an `IllegalArgumentException` will thrown.
+The Camel route defined in the workflow must be available in your project during runtime, otherwise, an `IllegalArgumentException` will be thrown.
 ====
 
-. To use the Camel function definition in a workflow action, you can simply reference to it as you normally would with any other {context} function definitions. For example:
+. To use the Camel function definition in a workflow action, you can simply reference it as you normally would with any other {context} function definitions. For example:
 +
 .Example of a workflow state action referencing
 [source,json]
@@ -119,11 +119,11 @@ The Camel Route defined in the workflow must be available in your project during
 <2> The body definition. A `jq` expression to be evaluated in runtime resulting in the body payload.
 <3> The `headers` definition that must be a key/value pair or a valid `jq` expression evaluated in runtime.
 
-Once a message is received back from the Camel route, the data is merged to the workflow payload.
+Once a message is received back from the Camel route, the data is merged into the workflow payload.
 
-== Example Project
+== Example project
 
-There's an link:{kogito_sw_examples_url}/serverless-workflow-camel-routes[example project available on GitHub] using this new feature. You can use it as a reference to have a better understanding of the Camel integration with {context}.
+There is an link:{kogito_sw_examples_url}/serverless-workflow-camel-routes[example project available on GitHub] using this new feature. You can use it as a reference to have a better understanding of the Camel integration with {context}.
 
 == Additional resources
 

--- a/serverlessworkflow/modules/ROOT/pages/integrations/camel-routes-integration.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/integrations/camel-routes-integration.adoc
@@ -37,20 +37,25 @@ You can add YAML or XML Camel routes to your workflow project.
 . The route response must be in a valid format that the workflow context can understand:
 +
 include::../../pages/_common-content/camel-valid-responses.adoc[]
-+
+
 The response will be merged into the workflow state context. If it is an array or a complex object, the response will be added to the special attribute `response`.
 
 .Example of a Camel route with the `direct` endpoint returning a valid JSON string representation
 [source,yaml]
 ----
 - from:
-    uri: direct:logRouteReplaceHeader
-    steps:
+    uri: direct:logRouteReplaceHeader <1>
+    steps: <2>
       - setBody:
-          simple: '{ "id": "${header.WorkflowID}", "arg1": { "arg2": "value1" } }'
+          simple: '{ "id": "${header.WorkflowID}", "arg1": { "arg2": "value1" } }' <3>
       - log:
-          message: We received the ${body}
+          message: We received the ${body} <4>
 ----
+
+<1> Camel route producer definition using the `direct` component
+<2> Definition of the Camel route steps
+<3> Replace the Camel message body with a valid JSON object containing the header `WorkflowID` from the workflow context
+<4> Log the Camel message body in the console for debugging purposes.
 
 [[con-importing-camel-routes]]
 == Defining and referencing Camel functions in the Workflow DSL
@@ -80,12 +85,12 @@ You can define and reference your Camel functions in the workflow definition.
 The operation description must have the prefix `camel:direct:`, indicating that you want to produce a message to this route via the link:{camel_extensions_url}/direct.html[Camel Direct Component]. Direct is the only component supported by {context} at the moment.
 +
 The `operation` suffix contains the name of the route endpoint. In the case of this example, `logRouteReplaceHeader`.
-
++
 [WARNING]
 ====
 The Camel route defined in the workflow must be available in your project during runtime, otherwise, an `IllegalArgumentException` will be thrown.
 ====
-
++
 . To use the Camel function definition in a workflow action, you can simply reference it as you normally would with any other {context} function definitions. For example:
 +
 .Example of a workflow state action referencing
@@ -118,8 +123,14 @@ The Camel route defined in the workflow must be available in your project during
 <1> The function reference name, as defined in the function attribute.
 <2> The body definition. A `jq` expression to be evaluated in runtime resulting in the body payload.
 <3> The `headers` definition that must be a key/value pair or a valid `jq` expression evaluated in runtime.
-
-Once a message is received back from the Camel route, the data is merged into the workflow payload.
++
+Once a message is received back from the Camel route, the data is merged into the workflow payload:
++
+.Message payload example returned by the Camel route
+[source,json]
+----
+{ "id": "777adb97-d297-45fd-9969-efafe4dfb3e7", "arg1": { "arg2": "value1" } }
+----
 
 == Example project
 
@@ -127,7 +138,7 @@ There is an link:{kogito_sw_examples_url}/serverless-workflow-camel-routes[examp
 
 == Additional resources
 
-* xref:core/custom-functions-support[Custom functions for your {context} service]
+* xref:core/custom-functions-support.adoc[Custom functions for your {context} service]
 * xref:core/understanding-jq-expressions.adoc[jq expressions in {context}]
 
 include::../../pages/_common-content/report-issue.adoc[]


### PR DESCRIPTION
Signed-off-by: Ricardo Zanini <zanini@redhat.com>

<!-- Please don't forget your JIRA link -->
**JIRA:** https://issues.redhat.com/browse/KOGITO-8353

<!-- If you don't have a JIRA link, please provide a short description of what this PR does -->
**Description:** In this PR, we introduce a new guide exemplifying how to use the new Camel Route custom function for Serverless Workflow.

<!-- Link to related PRs: -->

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributions doc](https://github.com/kiegroup/kogito-docs/blob/main/CONTRIBUTING.md)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [x] The nav.adoc file has a link to this guide in the proper category
- [x] The index.adoc file has a card to this guide in the proper category, with a meaningful description

<details>
<summary>
How to setup automatic cherry-pick to another branch ?
</summary>

The cherry-pick action allows to setup automatic cherry-pick from `main` to a specific branch.

To allow it, you will need to add the corresponding label with pattern: `backport-{RELEASE_BRANCH}`.  
For example, if a backport to branch `1.26.x` is needed, then the label should be `backport-1.26.x`.

Once the PR is merged, the action will retrieve the commit and cherry-pick it to the desired branch.

*NOTE: You can still add label after the merge and it should still be cherry-picked.*
</details>