### PR TITLE
Remove unnecessary quarkus-container-jib extension

### DIFF
--- a/serverlessworkflow/modules/ROOT/pages/getting-started/create-your-first-workflow-service.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/getting-started/create-your-first-workflow-service.adoc
@@ -57,7 +57,6 @@ quarkus create app \
 The previous command creates a Maven Quarkus project in the `serverless-workflow-hello-world` directory containing the required dependencies, including:
 
 * `{kogito_sw_ga}`: Adds support for workflows.
-* `quarkus-container-image-jib`: Adds support for Container Image Builds.
 * `quarkus-resteasy-jackson`: Adds support for RESTEasy, which is required by the generated REST resources that are used to start the flow process using an HTTP request.
 * `quarkus-smallrye-openapi`: Adds support for Swagger documentation when you run the application in development mode.
 * `--no-code`: Prevents workflow example code from being generated.
@@ -297,7 +296,6 @@ __  ____  __  _____   ___  __ ____  ______
 2022-05-25 14:38:12,890 INFO  [org.kie.kog.qua.pro.dev.DataIndexInMemoryContainer] (docker-java-stream--938264210) STDOUT: 2022-05-25 17:38:12,405 INFO  [io.zon.tes.db.pos.emb.EmbeddedPostgres] (main) 5df1ed6e-7a15-4091-bcfb-e293aa293bfe postmaster startup finished in 00:00:00.180
 2022-05-25 14:38:12,890 INFO  [org.kie.kog.qua.pro.dev.DataIndexInMemoryContainer] (docker-java-stream--938264210) STDOUT: 2022-05-25 17:38:12,405 INFO  [org.kie.kog.per.inm.pos.run.InmemoryPostgreSQLRecorder] (main) Embedded Postgres started at port "44729" with database "postgres", user "postgres" and password "postgres"
 2022-05-25 14:38:12,890 INFO  [org.kie.kog.qua.pro.dev.DataIndexInMemoryContainer] (docker-java-stream--938264210) STDOUT: 2022-05-25 17:38:12,636 WARN  [io.qua.run.con.ConfigRecorder] (main) Build time property cannot be changed at runtime:
-2022-05-25 14:38:12,891 INFO  [org.kie.kog.qua.pro.dev.DataIndexInMemoryContainer] (docker-java-stream--938264210) STDOUT:  - quarkus.jib.base-jvm-image is set to 'ba-docker-registry.usersys.redhat.com:5000/fabric8/java-alpine-openjdk11-jre' but it is build time fixed to 'fabric8/java-alpine-openjdk11-jre'. Did you change the property quarkus.jib.base-jvm-image after building the application?
 2022-05-25 14:38:13,375 INFO  [org.kie.kog.qua.pro.dev.DataIndexInMemoryContainer] (docker-java-stream--938264210) STDOUT: 2022-05-25 17:38:13,105 INFO  [org.kie.kog.per.pro.ProtobufService] (main) Registering Kogito ProtoBuffer file: kogito-index.proto
 2022-05-25 14:38:13,377 INFO  [org.kie.kog.qua.pro.dev.DataIndexInMemoryContainer] (docker-java-stream--938264210) STDOUT: 2022-05-25 17:38:13,132 INFO  [org.kie.kog.per.pro.ProtobufService] (main) Registering Kogito ProtoBuffer file: kogito-types.proto
 2022-05-25 14:38:13,378 INFO  [org.kie.kog.qua.pro.dev.DataIndexInMemoryContainer] (docker-java-stream--938264210) STDOUT: 2022-05-25 17:38:13,181 INFO  [io.quarkus] (main) data-index-service-inmemory 1.22.0.Final on JVM (powered by Quarkus 2.9.0.Final) started in 4.691s. Listening on: http://0.0.0.0:8080

--- a/serverlessworkflow/modules/ROOT/pages/getting-started/create-your-first-workflow-service.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/getting-started/create-your-first-workflow-service.adoc
@@ -48,7 +48,6 @@ Quarkus CLI::
 ----
 quarkus create app \
     -x={kogito_sw_ga} \
-    -x=quarkus-container-image-jib \
     -x=quarkus-resteasy-jackson \
     -x=quarkus-smallrye-openapi \
     --no-code \
@@ -74,7 +73,7 @@ Apache Maven::
 mvn {quarkus_platform}:quarkus-maven-plugin:{quarkus_version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=serverless-workflow-hello-world \
-    -Dextensions="{kogito_sw_ga},quarkus-container-image-jib,quarkus-resteasy-jackson,quarkus-smallrye-openapi" \
+    -Dextensions="{kogito_sw_ga},quarkus-resteasy-jackson,quarkus-smallrye-openapi" \
     -DnoCode
 cd serverless-workflow-hello-world
 ----


### PR DESCRIPTION
There's no apparent reason to add this dependency to the project. Users might use the Cloud Guides to build/generate the application image instead of adding the extension in the Getting Started.