### PR TITLE
KOGITO-8670 - Detach Quarkus Platform version from Quarkus version in…

### DIFF
--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -22,6 +22,10 @@ setupPostReleaseJob()
 KogitoJobUtils.createQuarkusUpdateToolsJob(this, 'kogito-docs', [:], [:], [[
     filepath: 'serverlessworkflow/antora.yml',
     regex: 'quarkus_version: ',
+],
+[
+    filepath: 'serverlessworkflow/antora.yml',
+    regex: 'quarkus_platform_version: ',
 ]])
 
 /////////////////////////////////////////////////////////////////

--- a/serverlessworkflow/antora.yml
+++ b/serverlessworkflow/antora.yml
@@ -24,6 +24,8 @@ asciidoc:
     kogito_sw_ga: kogito-quarkus-serverless-workflow
     # downstream: 2.7.6.Final-redhat-00006
     quarkus_version: 2.16.0.Final
+    # downstream: 2.7.6.Final-redhat-00006 (might be different to the quarkus_version)
+    quarkus_platform_version: 2.16.0.Final
     java_min_version: 11+
     maven_min_version: 3.8.6
     graalvm_min_version: 22.3.0

--- a/serverlessworkflow/modules/ROOT/pages/getting-started/create-your-first-workflow-service.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/getting-started/create-your-first-workflow-service.adoc
@@ -69,7 +69,7 @@ Apache Maven::
 .Create a project using Apache Maven
 [source,shell,subs="attributes"]
 ----
-mvn {quarkus_platform}:quarkus-maven-plugin:{quarkus_version}:create \
+mvn {quarkus_platform}:quarkus-maven-plugin:{quarkus_platform_version}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=serverless-workflow-hello-world \
     -Dextensions="{kogito_sw_ga},quarkus-resteasy-jackson,quarkus-smallrye-openapi" \
@@ -90,7 +90,7 @@ kn workflow create \
   --name serverless-workflow-hello-world \
   --extension quarkus-jsonp,quarkus-smallrye-openapi \
   --quarkus-platform-group-id={quarkus_platform} \
-  --quarkus-version={quarkus_version}
+  --quarkus-version={quarkus_platform_version}
 ----
 
 For more information about Knative workflow CLI, see xref:tooling/kn-plugin-workflow-overview.adoc[{context} plug-in for Knative CLI].
@@ -272,7 +272,7 @@ Also, to deploy and run your workflow application, see xref:cloud/deploying-on-m
 [INFO] Building serverless-workflow-hello-world 1.0.0-SNAPSHOT
 [INFO] --------------------------------[ jar ]---------------------------------
 [INFO]
-[INFO] --- quarkus-maven-plugin:{quarkus_version}:dev (default-cli) @ serverless-workflow-hello-world ---
+[INFO] --- quarkus-maven-plugin:{quarkus_platform_version}:dev (default-cli) @ serverless-workflow-hello-world ---
 [INFO] Invoking org.apache.maven.plugins:maven-resources-plugin:2.6:resources) @ serverless-workflow-hello-world
 [INFO] Using 'UTF-8' encoding to copy filtered resources.
 [INFO] Copying 3 resources


### PR DESCRIPTION
… docs

<!-- Please don't forget your JIRA link -->
**JIRA:** [KOGITO-8670](https://issues.redhat.com/browse/KOGITO-8670)

I have left `quarkus_version` in the following places:
* https://github.com/kiegroup/kogito-docs/blob/553fe5dee954d757b487acc56a787a15b4544e11/serverlessworkflow/modules/ROOT/pages/cloud/common/_proc_deploy_sw_kubectl.adoc?plain=1#L39
* https://github.com/kiegroup/kogito-docs/blob/553fe5dee954d757b487acc56a787a15b4544e11/serverlessworkflow/modules/ROOT/pages/getting-started/create-your-first-workflow-service.adoc?plain=1#L285
* https://github.com/kiegroup/kogito-docs/blob/553fe5dee954d757b487acc56a787a15b4544e11/serverlessworkflow/modules/ROOT/pages/tooling/quarkus-dev-ui-extension/quarkus-dev-ui-overview.adoc?plain=1#L18

@radtriste We need to update the `quarkus_platform_version` automatically as well when we are updating the Quarkus version. I noticed that here
https://github.com/kiegroup/kogito-docs/blob/553fe5dee954d757b487acc56a787a15b4544e11/.ci/jenkins/dsl/jobs.groovy#L22-L25
we update just the `quarkus_version`. In community the Quarkus version is equal to Quarkus platform version 99% of time, it's prod builds which cause issues, usually when a new SP build is created (participant release) which is based on the same Quarkus version. We can discuss that offline. But we could have another job probably, which would update just `quarkus_platform_version` in kogito-docs and ideally it would be run using the update ecosystem job we already have, just a new param will be needed.



<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>