### PR TITLE
Add a note to the db migration guide about default behavior

### DIFF
--- a/serverlessworkflow/modules/ROOT/pages/persistence/postgresql-flyway-migration.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/persistence/postgresql-flyway-migration.adoc
@@ -5,15 +5,15 @@
 :flyway_url: https://flywaydb.org/
 :flyway_baseline_migration_url: https://documentation.red-gate.com/fd/baseline-migrations-184127465.html
 
-Kogito provides an out-of-the-box way to manage your database schema changes with each upgrade. It uses link:{flyway_url}[Flyway] to achieve this functionality.
+When working with {context} PostgreSQL database, you can either opt to use link:{flyway_url}[Flyway] or manually upgrade your database via DDL scripts. 
 
-When you upgrade your Kogito version, by default it will pick up the latest changes available from Kogito and apply them automatically.
+When you upgrade your {context} version, by default it **won't** pick up the latest changes available.
 
 == How to migrate
 
 === Migrate using Flyway Config
 
-* Kogito provides a default mechanism for migrating your database while updating the Kogito version using the following `Flyway` properties (default value is `false`):
+* Kogito provides a mechanism for migrating your database while updating the Kogito version using the following `Flyway` properties (default value is `false`, not upgrade):
 +
 --
 [source,properties]


### PR DESCRIPTION
<!-- If you don't have a JIRA link, please provide a short description of what this PR does -->
**Description:**
Small update to the guide highlights that Flyway won't upgrade the database automatically.

@akumar074 @cristianonicolai feel free to update this PR directly. This is just a reminder that we must update the guide and backport it.

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>