### PR TITLE
KOGITO-8443 Added note about simplified format for Knative service discovery

### DIFF
--- a/serverlessworkflow/modules/ROOT/pages/cloud/kubernetes-service-discovery.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/kubernetes-service-discovery.adoc
@@ -30,6 +30,9 @@ The following scheme values are supported in the URI pattern:
 * `openshift`
 * `knative`
 
+> **NOTE**: When using `knative`, you can also use a simplified URI like:
+> `knative:<namespace>/<serviceName>`.
+
 The following resources are supported for the Kubernetes GVK (Group, Version, and Kind):
 
 * `v1/service`

--- a/serverlessworkflow/modules/ROOT/pages/cloud/kubernetes-service-discovery.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/kubernetes-service-discovery.adoc
@@ -30,9 +30,6 @@ The following scheme values are supported in the URI pattern:
 * `openshift`
 * `knative`
 
-> **NOTE**: When using `knative`, you can also use a simplified URI like:
-> `knative:<namespace>/<serviceName>`.
-
 The following resources are supported for the Kubernetes GVK (Group, Version, and Kind):
 
 * `v1/service`
@@ -44,10 +41,20 @@ The following resources are supported for the Kubernetes GVK (Group, Version, an
 * `route.openshift.io/v1/route`
 * `networking.k8s.io/v1/ingress`
 
+[NOTE]
+====
+When using `knative`, you can also use a simplified URI like:
+
+[source]
+----
+knative:<namespace>/<serviceName>
+----
+
+The above URI looks directly for serving.knative.dev/v1/service resource.
+====
+
 [IMPORTANT]
 ====
-The Kubernetes GVK is mandatory and cannot be empty. In case the Kubernetes GVK is empty, the engine throws a validation issue and discovery is not performed. The last value in the URI is always considered as resource name. 
-
 The `namespace` in the URI is optional, however, if `namespace` contains an empty value, the current namespace or context is used.
 ====
 


### PR DESCRIPTION
<!-- Please don't forget your JIRA link -->
**JIRA:** https://issues.redhat.com/browse/KOGITO-8443

<!-- Link to related PRs: -->
Related to: https://github.com/kiegroup/kogito-runtimes/pull/2924

----------

- [x] You have read the [contributions doc](https://github.com/kiegroup/kogito-docs/blob/main/CONTRIBUTING.md)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [x] The nav.adoc file has a link to this guide in the proper category
- [x] The index.adoc file has a card to this guide in the proper category, with a meaningful description

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>