### PR TITLE
Revert "[1.39.x] KOGITO-9144 Added information about how to enable service discovery"

### DIFF
--- a/serverlessworkflow/modules/ROOT/pages/cloud/quarkus/kubernetes-service-discovery.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/quarkus/kubernetes-service-discovery.adoc
@@ -168,27 +168,35 @@ Kubernetes service discovery is disabled::
 ----
 ====
 
-[[ref-enabling-kubernetes-service-discovery]]
-== Enabling Kubernetes service discovery
-
+[IMPORTANT]
+====
 When using the Kubernetes service discovery feature, you need to balance if your application can afford the delayed startup time.
 
 If the URI pattern is not found in the application properties, then discovery is not triggered. However, the scanning is performed anyway. Therefore, a short time is required to go through the startup scan.
 
-You can enable the Kubernetes service discovery by adding a service discovery implementation to the application's dependencies as shown in the following Maven dependencies:
+You can disable the Kubernetes service discovery by removing the `kogito-addons-quarkus-kubernetes` library from the application's dependencies as shown in the following Maven exclusions:
 
-.Example Maven dependencies
+.Example Maven exclusions
 [source,shell]
 ----
 <dependency>
-    <groupId>org.kie.kogito</groupId>
-    <artifactId>kogito-addons-quarkus-fabric8-kubernetes-service-catalog</artifactId>
+  <groupId>org.kie.kogito</groupId>
+  <artifactId>kogito-quarkus-serverless-workflow</artifactId>
+  <exclusions>
+    <exclusion>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-addons-quarkus-kubernetes</artifactId>
+    </exclusion>
+    <exclusion>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-addons-quarkus-kubernetes-deployment</artifactId>
+    </exclusion>
+  </exclusions>
 </dependency>
 ----
 
-=== Available service discovery implementations
+====
 
-Currently, only `org.kie.kogito:kogito-addons-quarkus-fabric8-kubernetes-service-catalog` is available. When enabled, it uses the Kubernetes Java API to discover the services.
 
 == Additional resources
 

--- a/serverlessworkflow/modules/ROOT/pages/integrations/custom-functions-knative.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/integrations/custom-functions-knative.adoc
@@ -33,8 +33,6 @@ include::../cloud/common/_prerequisites.adoc[]
 
 --
 
-. xref:cloud/quarkus/kubernetes-service-discovery.adoc#ref-enabling-kubernetes-service-discovery[Enable the Service Discovery feature].
-
 . Discover the name of the Knative service that your workflow will invoke. In a terminal window, run the following command:
 +
 --


### PR DESCRIPTION
Reverts kiegroup/kogito-docs#349

runtimes/examples PR are not in 1.39.x ...