### PR TITLE
KOGITO-9210 Fixed `org.kie.kogito.addons.knative` properties.

### DIFF
--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/configuring-workflows.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/configuring-workflows.adoc
@@ -63,7 +63,7 @@ A few properties can not be changed in this configuration. Usually, they are alr
 |0.0.0.0
 |all
 
-|org.kie.kogito.addons.knative.health-enabled
+|org.kie.kogito.addons.knative.eventing.health-enabled
 |false
 |dev
 

--- a/serverlessworkflow/modules/ROOT/pages/eventing/consume-produce-events-with-knative-eventing.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/eventing/consume-produce-events-with-knative-eventing.adoc
@@ -95,7 +95,7 @@ The following table lists the health check probe configuration property:
 |===
 |Property|Default value|Description
 
-|`org.kie.kogito.addons.knative.health_enabled`
+|`org.kie.kogito.addons.knative.eventing.health_enabled`
 |`true`
 |This property indicates if the health check is enabled to verify that the `K_SINK` variable is injected into the environment.
 
@@ -114,23 +114,23 @@ The following table lists the configuration properties related to Knative sink g
 |===
 |Property|Default value|Description
 
-|`org.kie.kogito.addons.knative.auto_generate_broker`
+|`org.kie.kogito.addons.knative.eventing.auto_generate_broker`
 |true
 |This property indicates if the Kogito Knative Eventing add-on generates a default Knative Broker in memory to sink and dispatch the messages. Set this property to `false` in case a broker is already installed in your namespace. Note that you can use `org.kie.kogito.addons.knative.eventing.sink.*` property to configure your custom sink. If this property is not set, then the auto-generated broker works as a sink.
 
-|`org.kie.kogito.addons.knative.sink.namespace`
+|`org.kie.kogito.addons.knative.eventing.sink.namespace`
 |
 |This property indicates the namespace where the generated Knative sink is deployed.
 
-|`org.kie.kogito.addons.knative.sink.api_version`
+|`org.kie.kogito.addons.knative.eventing.sink.api_version`
 |`eventing.knative.dev/v1`
 |This property indicates the API group and version of the generated Knative sink.
 
-|`org.kie.kogito.addons.knative.sink.name`
+|`org.kie.kogito.addons.knative.eventing.sink.name`
 |`default`
 |This property indicates the name of the generated Knative sink.
 
-|`org.kie.kogito.addons.knative.sink.kind`
+|`org.kie.kogito.addons.knative.eventing.sink.kind`
 |`Broker`
 |This property indicates the Kubernetes kind of the generated Knative sink.
 
@@ -150,7 +150,7 @@ The following table lists the configuration property related to Knative sink gen
 |===
 |Property|Default value|Description
 
-|`org.kie.kogito.addons.knative.broker`
+|`org.kie.kogito.addons.knative.eventing.broker`
 |`default`
 |This property indicates the name of the default Knative broker that is deployed in the Kubernetes namespace. This broker is used as the reference to create the Knative triggers, which are responsible to delegate the events that the workflow service consumes.
 


### PR DESCRIPTION
**JIRA:** https://issues.redhat.com/browse/KOGITO-9210

See this comment: https://issues.redhat.com/browse/KOGITO-9210?focusedId=22340763&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-22340763

- [x] You have read the [contributions doc](https://github.com/kiegroup/kogito-docs/blob/main/CONTRIBUTING.md)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [x] The nav.adoc file has a link to this guide in the proper category
- [x] The index.adoc file has a card to this guide in the proper category, with a meaningful description

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>