### PR TITLE
[Kogito-9243][KSW-GUIDE] KogitoServerlessWorkflow definition outdated

### DIFF
--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/developing-workflows.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/developing-workflows.adoc
@@ -31,39 +31,40 @@ metadata:
     sw.kogito.kie.org/version: 0.0.1
     sw.kogito.kie.org/profile: dev <1>
 spec: <2>
-  start: ChooseOnLanguage
-  functions:
-    - name: greetFunction
-      type: custom
-      operation: sysout
-  states:
-    - name: ChooseOnLanguage
-      type: switch
-      dataConditions:
-        - condition: "${ .language == \"English\" }"
-          transition: GreetInEnglish
-        - condition: "${ .language == \"Spanish\" }"
-          transition: GreetInSpanish
-      defaultCondition: GreetInEnglish
-    - name: GreetInEnglish
-      type: inject
-      data:
-        greeting: "Hello from JSON Workflow, "
-      transition: GreetPerson
-    - name: GreetInSpanish
-      type: inject
-      data:
-        greeting: "Saludos desde JSON Workflow, "
-      transition: GreetPerson
-    - name: GreetPerson
-      type: operation
-      actions:
-        - name: greetAction
-          functionRef:
-            refName: greetFunction
-            arguments:
-              message:  ".greeting+.name"
-      end: true
+  flow:
+    start: ChooseOnLanguage
+    functions:
+      - name: greetFunction
+        type: custom
+        operation: sysout
+    states:
+      - name: ChooseOnLanguage
+        type: switch
+        dataConditions:
+          - condition: "${ .language == \"English\" }"
+            transition: GreetInEnglish
+          - condition: "${ .language == \"Spanish\" }"
+            transition: GreetInSpanish
+        defaultCondition: GreetInEnglish
+      - name: GreetInEnglish
+        type: inject
+        data:
+          greeting: "Hello from JSON Workflow, "
+        transition: GreetPerson
+      - name: GreetInSpanish
+        type: inject
+        data:
+          greeting: "Saludos desde JSON Workflow, "
+        transition: GreetPerson
+      - name: GreetPerson
+        type: operation
+        actions:
+          - name: greetAction
+            functionRef:
+              refName: greetFunction
+              arguments:
+                message:  ".greeting+.name"
+        end: true
 ----
 
 <1> The annotation `sw.kogito.kie.org/profile: dev` tells the operator to deploy your workflow using the development profile. This means that the operator will build a running instance of the workflow ready to receive changes during your development cycle.


### PR DESCRIPTION
See: https://issues.redhat.com/browse/KOGITO-9243
<!-- Please don't forget your JIRA link -->
**JIRA:**

<!-- If you don't have a JIRA link, please provide a short description of what this PR does -->
**Description:**

<!-- Link to related PRs: -->

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributions doc](https://github.com/kiegroup/kogito-docs/blob/main/CONTRIBUTING.md)
- [ ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [ ] The nav.adoc file has a link to this guide in the proper category
- [ ] The index.adoc file has a card to this guide in the proper category, with a meaningful description

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>