### PR TITLE
[KOGITO-9315] Updating docs to include Kogito Kubernetes Add-on to Discovery

### DIFF
--- a/serverlessworkflow/modules/ROOT/pages/cloud/quarkus/kubernetes-service-discovery.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/quarkus/kubernetes-service-discovery.adoc
@@ -6,9 +6,9 @@
 // links
 :quarkus_issue_url: https://github.com/quarkusio/quarkus/issues/27457
 
-The Kubernetes service discovery allows you to describe the Kubernetes resource you want to perform an HTTP request using a custom URI. Under the hood, it will discover the network endpoint (URL) to where to make the request.
+The Kubernetes service discovery allows you to describe the Kubernetes resource you want to perform HTTP requests using a custom URI. Under the hood, it will discover the network endpoint (URL) to where to make the request.
 
-The Kubernetes service discovery feature works during the workflow application startup, in which this feature scans all the Quarkus configuration in search of the URI pattern. Therefore, you must keep in mind that if application startup time matters, then consider to use a known static URL instead.
+The Kubernetes service discovery feature works during the workflow application startup, in which this feature scans all the Quarkus configurations in search of the URI pattern. Therefore, you must remember that if the application startup time matters, consider using a known static URL instead.
 
 Following is the custom URI pattern in Kubernetes service discovery:
 
@@ -147,7 +147,7 @@ __  ____  __  _____   ___  __ ____  ______
 
 [NOTE]
 ====
-In the previous example, the URI is translated to `http://greeting-quarkus-cli.serverless-workflow-greeting-quarkus.10.99.154.147.sslip.io` when the application started. The translated URL is used at runtime, when needed.
+In the previous example, the URI is translated to `http://greeting-quarkus-cli.serverless-workflow-greeting-quarkus.10.99.154.147.sslip.io` when the application started. The translated URL is used at runtime when needed.
 ====
 
 The Kubernetes service discovery scans the Quarkus configuration during the startup, which can also cause small delay as follows:

--- a/serverlessworkflow/modules/ROOT/pages/cloud/quarkus/kubernetes-service-discovery.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/quarkus/kubernetes-service-discovery.adoc
@@ -6,7 +6,7 @@
 // links
 :quarkus_issue_url: https://github.com/quarkusio/quarkus/issues/27457
 
-The Kubernetes service discovery allows you to describe the Kubernetes resource you want to perform HTTP requests using a custom URI. Under the hood, it will discover the network endpoint (URL) to where to make the request.
+The Kubernetes service discovery allows you to describe the Kubernetes resource you want to perform HTTP requests on using a custom URI. Under the hood, it will discover the network endpoint (URL) to where to make the request.
 
 The Kubernetes service discovery feature works during the workflow application startup, in which this feature scans all the Quarkus configurations in search of the URI pattern. Therefore, you must remember that if the application startup time matters, consider using a known static URL instead.
 

--- a/serverlessworkflow/modules/ROOT/pages/cloud/quarkus/kubernetes-service-discovery.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/quarkus/kubernetes-service-discovery.adoc
@@ -6,11 +6,11 @@
 // links
 :quarkus_issue_url: https://github.com/quarkusio/quarkus/issues/27457
 
-The Kubernetes service discovery allows you to have a static URI, defining a Kubernetes resource, which is used to perform HTTP requests. The Kubernetes resource defined in the URI is queried in the current Kubernetes cluster and translated in a valid URL. 
+The Kubernetes service discovery allows you to describe the Kubernetes resource you want to perform an HTTP request using a custom URI. Under the hood, it will discover the network endpoint (URL) to where to make the request.
 
-The Kubernetes service discovery feature works during the workflow application startup, in which this feature scans all the Quarkus configuration in search of the URI pattern. Therefore, you must keep in mind that if application startup time matters, then consider to use a static URL instead.
+The Kubernetes service discovery feature works during the workflow application startup, in which this feature scans all the Quarkus configuration in search of the URI pattern. Therefore, you must keep in mind that if application startup time matters, then consider to use a known static URL instead.
 
-Following is the URI pattern in Kubernetes service discovery:
+Following is the custom URI pattern in Kubernetes service discovery:
 
 .URI pattern in Kubernetes service discovery
 [source,shell]
@@ -147,7 +147,7 @@ __  ____  __  _____   ___  __ ____  ______
 
 [NOTE]
 ====
-In the previous example, the URI is translated to `http://greeting-quarkus-cli.serverless-workflow-greeting-quarkus.10.99.154.147.sslip.io` when the application started. The translated URI is used at runtime, when needed.
+In the previous example, the URI is translated to `http://greeting-quarkus-cli.serverless-workflow-greeting-quarkus.10.99.154.147.sslip.io` when the application started. The translated URL is used at runtime, when needed.
 ====
 
 The Kubernetes service discovery scans the Quarkus configuration during the startup, which can also cause small delay as follows:
@@ -178,9 +178,14 @@ If the URI pattern is not found in the application properties, then discovery is
 You can enable the Kubernetes service discovery by adding a service discovery implementation to the application's dependencies as shown in the following Maven dependencies:
 
 .Example Maven dependencies
-[source,shell]
+[source,xml]
 ----
 <dependency>
+    <!-- Service Discovery -->
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-addons-quarkus-kubernetes</artifactId>
+    </dependency>
     <groupId>org.kie.kogito</groupId>
     <artifactId>kogito-addons-quarkus-fabric8-kubernetes-service-catalog</artifactId>
 </dependency>


### PR DESCRIPTION
<!-- Please don't forget your JIRA link -->
**JIRA:** https://issues.redhat.com/browse/KOGITO-9315

<!-- If you don't have a JIRA link, please provide a short description of what this PR does -->
**Description:** Small update to the discovery guide to include the kogito kubernetes add-on additionally to the fabric8 one.

Depends on:

- https://github.com/kiegroup/kogito-runtimes/pull/3056

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>