### PR TITLE
Improve contributing guidelines for release notes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -214,13 +214,24 @@ More details at [Antora documentation](https://docs.antora.org/antora/latest/asc
 
 ## Generating Release Notes for Serverless Workflow
 
-1. Use the [JIRA to search for the issues](https://issues.redhat.com/issues/?jql=) with:
+1. You can retrieve all changes in the release page of each repository of the project:
 
-```
-project = Kogito and fixVersion = <version> and component in ("Serverless Workflow Editor", "Serverless Workflow Engine") AND status in (Resolved, Done)  and type != Sub-task and type != Epic
-```
+    - https://github.com/kiegroup/kogito-runtimes/releases/tag/{version}
+    - https://github.com/kiegroup/kogito-apps/releases/tag/{version}
+    - https://github.com/kiegroup/kogito-examples/releases/tag/{version}
+    - https://github.com/kiegroup/kogito-images/releases/tag/{version_without_Final}
+    - https://github.com/kiegroup/kogito-serverless-operator/releases/tag/v{version_without_Final}
 
-Replace `<version>` with the given version, for example `1.35.0.Final`.
+   Replace `{version}` with the given core version, for example `1.41.0.Final`.  
+   Replace `{version_without_Final}` with the given cloud version, for example `1.41.0`.
+
+   You should also get JIRA issues with `KOGITO` and `DROOLS` projects as well as issues coming from the `kie-issues` repository. An example of a filter for `KOGITO` JIRA project:
+
+   ```
+   project = Kogito and fixVersion = <version> and component in ("Serverless Workflow Editor", "Serverless Workflow Engine") AND status in (Resolved, Done)  and type != Sub-task and type != Epic
+   ```
+
+   Replace `<version>` with the given version, for example `1.41.0.Final`.
 
 2. Update the page [release_notes.adoc](serverlessworkflow/modules/ROOT/pages/release_notes.adoc)
 3. Align with the team what should be under "Notable changes"


### PR DESCRIPTION
Backport to main of contributing guidelines from #372.

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>