### PR TITLE
Remove specVersion property from example

### DIFF
--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/developing-workflows.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/developing-workflows.adoc
@@ -35,7 +35,6 @@ metadata:
     sonataflow.org/profile: dev <1>
 spec:
   flow: <2>
-    specVersion: 0.8.0
     start: ChooseOnLanguage
     functions:
       - name: greetFunction


### PR DESCRIPTION
<!-- If you don't have a JIRA link, please provide a short description of what this PR does -->
**Description:**

Operator [v1.42](quay.io/kiegroup/kogito-serverless-operator:1.42) doesn't support the `specVersion` in SonataFlow CRD. Updating the example not to fail with:
```
Error from server (BadRequest): error when creating "example.yaml": SonataFlow in version "v1alpha08" cannot be handled as a SonataFlow: strict decoding error: unknown field "spec.flow.specVersion"
```
