### PR TITLE
KOGITO-8410 Added documentation about GET requests to Knative Custom Functions

### DIFF
--- a/serverlessworkflow/modules/ROOT/pages/core/custom-functions-support.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/core/custom-functions-support.adoc
@@ -342,7 +342,7 @@ The above function will send a `POST` request to the http://custom-function-knat
 
 [NOTE]
 ====
-You can also send `GET` requests by setting `method=GET` in `operation`.
+You can also send `GET` requests by setting `method=GET` in `operation`. In this case, the arguments are sent over query string.
 ====
 
 .Example of a `GET` request

--- a/serverlessworkflow/modules/ROOT/pages/core/custom-functions-support.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/core/custom-functions-support.adoc
@@ -342,7 +342,7 @@ The above function will send a `POST` request to the http://custom-function-knat
 
 [NOTE]
 ====
-You can also send `GET` requests by setting `method=GET` in `operation`. In this case, the arguments are sent over query string.
+You can also send `GET` requests by setting `method=GET` in `operation`. In this case, the arguments are forwarded over a query string.
 ====
 
 .Example of a `GET` request

--- a/serverlessworkflow/modules/ROOT/pages/core/custom-functions-support.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/core/custom-functions-support.adoc
@@ -342,8 +342,22 @@ The above function will send a `POST` request to the http://custom-function-knat
 
 [NOTE]
 ====
-`GET` requests are not yet supported.
+You can also send `GET` requests by setting `method=GET` in `operation`.
 ====
+
+.Example of a `GET` request
+[source,json]
+----
+  "functions": [
+    {
+      "name": "greet",
+      "type": "custom",
+      "operation": "knative:services.v1.serving.knative.dev/custom-function-knative-service?path=/plainJsonFunction&method=GET", <1>
+    }
+  ]
+----
+
+<1> `GET` request
 
 [[about-namespaces]]
 ==== About namespaces


### PR DESCRIPTION
**JIRA:** https://issues.redhat.com/browse/KOGITO-8410

<!-- Link to related PRs: -->
This PR depends on:

- https://github.com/kiegroup/kogito-runtimes/pull/3172

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributions doc](https://github.com/kiegroup/kogito-docs/blob/main/CONTRIBUTING.md)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [x] The nav.adoc file has a link to this guide in the proper category
- [x] The index.adoc file has a card to this guide in the proper category, with a meaningful description

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>