### PR TITLE
KOGITO-9757 Changed property expansion to use ${property_name}

### DIFF
--- a/serverlessworkflow/modules/ROOT/pages/cloud/quarkus/kubernetes-service-discovery.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/quarkus/kubernetes-service-discovery.adoc
@@ -212,7 +212,7 @@ For example, consider an application that consumes a resource running on Kuberne
 .Example URI
 [source,shell]
 ----
-org.kie.kogito.sw.knative.service=knative:services.v1/serverless-workflow-greeting-quarkus/greeting-quarkus-cli
+org.kie.kogito.sw.knative.service=${knative:services.v1/serverless-workflow-greeting-quarkus/greeting-quarkus-cli}
 ----
 
 [NOTE]

--- a/serverlessworkflow/modules/ROOT/pages/cloud/quarkus/kubernetes-service-discovery.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/quarkus/kubernetes-service-discovery.adoc
@@ -215,6 +215,14 @@ For example, consider an application that consumes a resource running on Kuberne
 org.kie.kogito.sw.knative.service=${knative:services.v1/serverless-workflow-greeting-quarkus/greeting-quarkus-cli}
 ----
 
+Or you can reference a specific endpoint of the Knative service using the following URI:
+
+.Example endpoint URI
+[source,shell]
+----
+org.kie.kogito.sw.knative.service=${knative:services.v1/serverless-workflow-greeting-quarkus/greeting-quarkus-cli}/endpoint
+----
+
 [NOTE]
 ====
 The service discovery engine does not read the application property `name`, but only `value`.


### PR DESCRIPTION
<!-- Please don't forget your JIRA link -->
**JIRA:** https://issues.redhat.com/browse/KOGITO-9757

<!-- Link to related PRs: -->
This PR depends on:

- https://github.com/kiegroup/kogito-runtimes/pull/3188

------

- [x] You have read the [contributions doc](https://github.com/kiegroup/kogito-docs/blob/main/CONTRIBUTING.md)
- [x] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [x] The nav.adoc file has a link to this guide in the proper category
- [x] The index.adoc file has a card to this guide in the proper category, with a meaningful description

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>