### PR TITLE
[KOGITO-9184] Describing how to pass args and envs to the SonataFlow build process

### DIFF
--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/build-and-deploy-workflows.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/build-and-deploy-workflows.adoc
@@ -10,8 +10,10 @@
 :kaniko_url: https://github.com/GoogleContainerTools/kaniko
 :openshift_build_url: https://docs.openshift.com/container-platform/4.13/cicd/builds/understanding-image-builds.html
 :openshift_route_new_url: https://docs.openshift.com/container-platform/4.13/networking/routes/route-configuration.html#nw-creating-a-route_route-configuration
-:kubernetes_resource_management: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+:kubernetes_resource_management_url: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+:kubernetes_envvar_url: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
 :minikube_registry_url: https://minikube.sigs.k8s.io/docs/handbook/registry/#enabling-insecure-registries
+:docker_doc_arg_url: https://docs.docker.com/engine/reference/builder/#arg
 
 This document describes how to build and deploy your workflow on a cluster using the link:{kogito_serverless_operator_url}[{operator_name}] only by having a `SonataFlow` custom resource.
 
@@ -82,7 +84,7 @@ The excerpt above is just an example. The current version might have a slightly 
 
 === Changing resources requirements
 
-You can create or edit a `SonataFlowPlatform` in the workflow namespace specifying the link:{kubernetes_resource_management}[resources requirements] for the internal builder pods:
+You can create or edit a `SonataFlowPlatform` in the workflow namespace specifying the link:{kubernetes_resource_management_url}[resources requirements] for the internal builder pods:
 
 .Example of SonataFlowPlatform
 [source,yaml,subs="attributes+"]
@@ -130,6 +132,125 @@ spec:
 ----
 
 This parameters will only apply to new build instances.
+
+=== Passing arguments to the internal builder
+
+You can pass build arguments (see link:{docker_doc_arg_url}[Dockerfile ARG]) to the `SonataFlowBuild` instance.
+
+.Procedure
+
+1. Create or edit an existing `SonataFlowBuild` instance. It has the same name of the `SonataFlow` you're trying to build.
++
+.Checking if the SonataFlowBuild instance already exists
+[source,bash,subs="attributes+"]
+----
+# Check if the build exists
+kubectl get sfbuild/<name> -n <namespace>
+----
++
+2. Add to the `.spec.buildArgs` the desired arguments.
+.Adding buildArgs to the SonataFlowBuild instance
+[source,yaml,subs="attributes+"]
+----
+apiVersion: sonataflow.org/v1alpha08
+kind: SonataFlowBuild
+metadata:
+  name: <name>
+spec:
+  buildArgs:
+    - name: ARG1
+      value: value1
+    - name: ARG2
+      value: value2
+----
++
+3. Save the file and apply it to the cluster. A new build should start soon with the new configuration.
+
+Alternatively, you can set this information in the `SonataFlowPlatform`, so that every new build instances will use it as a template. For example:
+
+.Example of a SonataFlowPlatform instance with default build args for every build within the namespace
+[source,yaml,subs="attributes+"]
+----
+apiVersion: sonataflow.org/v1alpha08
+kind: SonataFlowPlatform
+metadata:
+  name: <name>
+spec:
+  build:
+    template:
+      buildArgs:
+        - name: ARG1
+          value: value1
+        - name: ARG2
+          value: value2
+----
+
+[TIP]
+====
+Since the `buildArgs` attribute is an array of link:{kubernetes_envvar_url}[Kubernetes `EnvVar`] object, you can refer to a `ConfigMap` or `Secret` to pass this value, for example. You're not restricted by a plain value. On Minikube and Kubernetes, only `ConfigMap` and `Secret` are supported duo to a restriction on the build system provided by these platforms.
+====
+
+=== Setting environment variables in the internal builder
+
+You can set environment variables to the `SonataFlowBuild` internal builder pod. 
+
+[IMPORTANT]
+====
+These environment variables are valid for the build context **only**. They are not set on the final built workflow image.
+====
+
+.Procedure
+
+1. Create or edit an existing `SonataFlowBuild` instance. It has the same name of the `SonataFlow` you're trying to build.
++
+.Checking if the SonataFlowBuild instance already exists
+[source,bash,subs="attributes+"]
+----
+# Check if the build exists
+kubectl get sfbuild/<name> -n <namespace>
+----
++
+2. Add to the `.spec.envs` the desired data.
+.Setting environment variables in the SonataFlowBuild instance
+[source,yaml,subs="attributes+"]
+----
+apiVersion: sonataflow.org/v1alpha08
+kind: SonataFlowBuild
+metadata:
+  name: <name>
+spec:
+  envs:
+    - name: MYENV1
+      value: value1
+    - name: MYENV2
+      value: value2
+----
++
+3. Save the file and apply it to the cluster. A new build should start soon with the new configuration.
+
+Alternatively, you can set this information in the `SonataFlowPlatform`, so that every new build instances will use it as a template. For example:
+
+.Example of a SonataFlowPlatform instance with default build args for every build within the namespace
+[source,yaml,subs="attributes+"]
+----
+apiVersion: sonataflow.org/v1alpha08
+kind: SonataFlowPlatform
+metadata:
+  name: <name>
+spec:
+  build:
+    template:
+      envs:
+        - name: MYENV1
+          value: value1
+        - name: MYENV2
+          value: value2
+----
+
+[TIP]
+====
+Since the `envs` attribute is an array of link:{kubernetes_envvar_url}[Kubernetes `EnvVar`] object, you can refer to a `ConfigMap` or `Secret` to pass this value. You're not restricted by a plain value. On Minikube and Kubernetes, only `ConfigMap` and `Secret` are supported duo to a restriction on the build system provided by these platforms.
+====
 
 [#building-kubernetes]
 == Building on Kubernetes
@@ -276,6 +397,7 @@ You can find a basic `SonataFlow` bellow:
 
 .Example of the greetings workflow example
 [source,yaml,subs="attributes+"]
+----
 apiVersion: sonataflow.org/v1alpha08
 kind: SonataFlow
 metadata:
@@ -318,6 +440,7 @@ spec:
               arguments:
                 message:  ".greeting+.name"
         end: true
+----
 
 Save a file in your local file system with this contents named `greetings-workflow.yaml` then run:
 

--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/build-and-deploy-workflows.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/build-and-deploy-workflows.adoc
@@ -145,8 +145,7 @@ You can pass build arguments (see link:{docker_doc_arg_url}[Dockerfile ARG]) to 
 .Checking if the SonataFlowBuild instance already exists
 [source,bash,subs="attributes+"]
 ----
-# Check if the build exists
-kubectl get sfbuild/<name> -n <namespace>
+kubectl edit sonataflowbuild/<name> -n <namespace>
 ----
 +
 2. Add to the `.spec.buildArgs` the desired arguments.
@@ -159,6 +158,7 @@ kind: SonataFlowBuild
 metadata:
   name: <name>
 spec:
+  [...]
   buildArgs:
     - name: ARG1
       value: value1
@@ -166,7 +166,7 @@ spec:
       value: value2
 ----
 +
-3. Save the file and apply it to the cluster. A new build should start soon with the new configuration.
+3. Save the file and exit. A new build should start soon with the new configuration.
 
 Alternatively, you can set this information in the `SonataFlowPlatform`, so that every new build instance will use it as a template. For example:
 
@@ -219,8 +219,7 @@ These environment variables are valid for the build context **only**. They are n
 .Checking if the SonataFlowBuild instance already exists
 [source,bash,subs="attributes+"]
 ----
-# Check if the build exists
-kubectl get sfbuild/<name> -n <namespace>
+kubectl edit sonataflowbuild/<name> -n <namespace>
 ----
 +
 2. Add to the `.spec.envs` the desired data.
@@ -233,6 +232,7 @@ kind: SonataFlowBuild
 metadata:
   name: <name>
 spec:
+  [...]
   envs:
     - name: MYENV1
       value: value1
@@ -240,11 +240,11 @@ spec:
       value: value2
 ----
 +
-3. Save the file and apply it to the cluster. A new build should start soon with the new configuration.
+3. Save the file and exit. A new build should start soon with the new configuration.
 
 Alternatively, you can set this information in the `SonataFlowPlatform`, so that every new build instances will use it as a template. For example:
 
-.Example of a SonataFlowPlatform instance with default build args for every build within the namespace
+.Example of a SonataFlowPlatform instance with default envs for every build within the namespace
 [source,yaml,subs="attributes+"]
 ----
 apiVersion: sonataflow.org/v1alpha08

--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/build-and-deploy-workflows.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/build-and-deploy-workflows.adoc
@@ -149,6 +149,7 @@ kubectl get sfbuild/<name> -n <namespace>
 ----
 +
 2. Add to the `.spec.buildArgs` the desired arguments.
++
 .Adding buildArgs to the SonataFlowBuild instance
 [source,yaml,subs="attributes+"]
 ----
@@ -187,7 +188,7 @@ spec:
 
 [TIP]
 ====
-Since the `buildArgs` attribute is an array of link:{kubernetes_envvar_url}[Kubernetes `EnvVar`] object, you can refer to a `ConfigMap` or `Secret` to pass this value, for example. You're not restricted by a plain value. On Minikube and Kubernetes, only `ConfigMap` and `Secret` are supported duo to a restriction on the build system provided by these platforms.
+Since the `buildArgs` attribute is an array of link:{kubernetes_envvar_url}[Kubernetes `EnvVar` object], you can refer to a `ConfigMap` or `Secret` to pass this value. You're not restricted by a plain value. On Minikube and Kubernetes, only `ConfigMap` and `Secret` are supported duo to a restriction on the build system provided by these platforms.
 ====
 
 === Setting environment variables in the internal builder
@@ -211,6 +212,7 @@ kubectl get sfbuild/<name> -n <namespace>
 ----
 +
 2. Add to the `.spec.envs` the desired data.
++
 .Setting environment variables in the SonataFlowBuild instance
 [source,yaml,subs="attributes+"]
 ----
@@ -249,7 +251,7 @@ spec:
 
 [TIP]
 ====
-Since the `envs` attribute is an array of link:{kubernetes_envvar_url}[Kubernetes `EnvVar`] object, you can refer to a `ConfigMap` or `Secret` to pass this value. You're not restricted by a plain value. On Minikube and Kubernetes, only `ConfigMap` and `Secret` are supported duo to a restriction on the build system provided by these platforms.
+Since the `envs` attribute is an array of link:{kubernetes_envvar_url}[Kubernetes `EnvVar` object], you can refer to a `ConfigMap` or `Secret` to pass this value. You're not restricted by a plain value. On Minikube and Kubernetes, only `ConfigMap` and `Secret` are supported duo to a restriction on the build system provided by these platforms.
 ====
 
 [#building-kubernetes]

--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/build-and-deploy-workflows.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/build-and-deploy-workflows.adoc
@@ -15,7 +15,6 @@
 :minikube_registry_url: https://minikube.sigs.k8s.io/docs/handbook/registry/#enabling-insecure-registries
 :docker_doc_arg_url: https://docs.docker.com/engine/reference/builder/#arg
 :quarkus_extensions_url: https://quarkus.io/extensions/
-:quarkus_cli_url: https://quarkus.io/guides/cli-tooling#using-the-cli
 
 This document describes how to build and deploy your workflow on a cluster using the link:{kogito_serverless_operator_url}[{operator_name}] only by having a `SonataFlow` custom resource.
 
@@ -169,7 +168,7 @@ spec:
 +
 3. Save the file and apply it to the cluster. A new build should start soon with the new configuration.
 
-Alternatively, you can set this information in the `SonataFlowPlatform`, so that every new build instances will use it as a template. For example:
+Alternatively, you can set this information in the `SonataFlowPlatform`, so that every new build instance will use it as a template. For example:
 
 .Example of a SonataFlowPlatform instance with default build args for every build within the namespace
 [source,yaml,subs="attributes+"]
@@ -201,7 +200,7 @@ The table below lists the Dockerfile arguments available in the default {operato
 | Argument | Description | Example
 
 |QUARKUS_EXTENSIONS | List of link:{quarkus_extensions_url}[Quarkus Extensions] separated by comma that the builder should add to the workflow. | org.kie.kogito:kogito-addons-quarkus-persistence-infinispan:2.0.0-SNAPSHOT
-|QUARKUS_ADD_EXTENSION_ARGS | Arguments passed to the Quarkus CLI when adding extensions. Enabled only when `QUARKUS_EXTENSIONS` is not empty. | See the link:{quarkus_cli_url}[Quarkus CLI documentation]
+|QUARKUS_ADD_EXTENSION_ARGS | Arguments passed to the Quarkus CLI when adding extensions. Enabled only when `QUARKUS_EXTENSIONS` is not empty. | See the link:{quarkus_cli_url}#using-the-cli[Quarkus CLI documentation]
 |===
 
 === Setting environment variables in the internal builder

--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/build-and-deploy-workflows.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/build-and-deploy-workflows.adoc
@@ -189,7 +189,9 @@ spec:
 
 [TIP]
 ====
-Since the `buildArgs` attribute is an array of link:{kubernetes_envvar_url}[Kubernetes `EnvVar` object], you can refer to a `ConfigMap` or `Secret` to pass this value. You're not restricted by a plain value. On Minikube and Kubernetes, only `ConfigMap` and `Secret` are supported due to a restriction on the build system provided by these platforms.
+Since the `buildArgs` attribute is an array of link:{kubernetes_envvar_url}[Kubernetes `EnvVar` object], you can refer to a `ConfigMap` or `Secret` to pass this value, for example. You're not restricted by a plain value. 
+
+On Minikube and Kubernetes only plain values, `ConfigMap` and `Secret` are supported due to a restriction on the build system provided by these platforms.
 ====
 
 The table below lists the Dockerfile arguments available in the default {operator_name} installation:
@@ -263,7 +265,9 @@ spec:
 
 [TIP]
 ====
-Since the `envs` attribute is an array of link:{kubernetes_envvar_url}[Kubernetes `EnvVar` object], you can refer to a `ConfigMap` or `Secret` to pass this value. You're not restricted by a plain value. On Minikube and Kubernetes, only `ConfigMap` and `Secret` are supported duo to a restriction on the build system provided by these platforms.
+Since the `envs` attribute is an array of link:{kubernetes_envvar_url}[Kubernetes `EnvVar` object], you can refer to a `ConfigMap` or `Secret` to pass this value, for example. You're not restricted by a plain value. 
+
+On Minikube and Kubernetes only plain values, `ConfigMap` and `Secret` are supported due to a restriction on the build system provided by these platforms.
 ====
 
 [#building-kubernetes]

--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/build-and-deploy-workflows.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/build-and-deploy-workflows.adoc
@@ -190,7 +190,7 @@ spec:
 
 [TIP]
 ====
-Since the `buildArgs` attribute is an array of link:{kubernetes_envvar_url}[Kubernetes `EnvVar` object], you can refer to a `ConfigMap` or `Secret` to pass this value. You're not restricted by a plain value. On Minikube and Kubernetes, only `ConfigMap` and `Secret` are supported duo to a restriction on the build system provided by these platforms.
+Since the `buildArgs` attribute is an array of link:{kubernetes_envvar_url}[Kubernetes `EnvVar` object], you can refer to a `ConfigMap` or `Secret` to pass this value. You're not restricted by a plain value. On Minikube and Kubernetes, only `ConfigMap` and `Secret` are supported due to a restriction on the build system provided by these platforms.
 ====
 
 The table below lists the Dockerfile arguments available in the default {operator_name} installation:

--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/build-and-deploy-workflows.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/build-and-deploy-workflows.adoc
@@ -14,6 +14,8 @@
 :kubernetes_envvar_url: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
 :minikube_registry_url: https://minikube.sigs.k8s.io/docs/handbook/registry/#enabling-insecure-registries
 :docker_doc_arg_url: https://docs.docker.com/engine/reference/builder/#arg
+:quarkus_extensions_url: https://quarkus.io/extensions/
+:quarkus_cli_url: https://quarkus.io/guides/cli-tooling#using-the-cli
 
 This document describes how to build and deploy your workflow on a cluster using the link:{kogito_serverless_operator_url}[{operator_name}] only by having a `SonataFlow` custom resource.
 
@@ -190,6 +192,17 @@ spec:
 ====
 Since the `buildArgs` attribute is an array of link:{kubernetes_envvar_url}[Kubernetes `EnvVar` object], you can refer to a `ConfigMap` or `Secret` to pass this value. You're not restricted by a plain value. On Minikube and Kubernetes, only `ConfigMap` and `Secret` are supported duo to a restriction on the build system provided by these platforms.
 ====
+
+The table below lists the Dockerfile arguments available in the default {operator_name} installation:
+
+.Default ARG definitions in the builder Dockerfile
+[cols="1,1,1"]
+|===
+| Argument | Description | Example
+
+|QUARKUS_EXTENSIONS | List of link:{quarkus_extensions_url}[Quarkus Extensions] separated by comma that the builder should add to the workflow. | org.kie.kogito:kogito-addons-quarkus-persistence-infinispan:2.0.0-SNAPSHOT
+|QUARKUS_ADD_EXTENSION_ARGS | Arguments passed to the Quarkus CLI when adding extensions. Enabled only when `QUARKUS_EXTENSIONS` is not empty. | See the link:{quarkus_cli_url}[Quarkus CLI documentation]
+|===
 
 === Setting environment variables in the internal builder
 


### PR DESCRIPTION
<!-- Please don't forget your JIRA link -->
**JIRA:**
https://issues.redhat.com/browse/KOGITO-9184

<!-- If you don't have a JIRA link, please provide a short description of what this PR does -->
**Description:**
This small update reflects the new feature added by the linked JIRA.

<!-- Link to related PRs: -->

- https://github.com/kiegroup/kogito-serverless-operator/pull/246/

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>